### PR TITLE
Introduce responsive elements to support a wide variety of screens.

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -46,8 +46,11 @@ if (interactive()) {
 
         # Shortcuts to run development scripts.
         .find <- \() invisible(source(file.path(".scripts", "find-text.R")))
-        .pub  <- \() invisible(source(file.path(".scripts", "publish.R")))
         .run  <- \() invisible(source(file.path(".scripts", "run.R")))
+        .pub  <- \(...) {
+            source(file.path(".scripts", "publish.R"), TRUE)
+            return(invisible(publish(...)))
+        }
 
         # Clear the global environment.
         .rm <- \() rm(list = ls(name = globalenv()), pos = globalenv())

--- a/.scripts/publish.R
+++ b/.scripts/publish.R
@@ -2,37 +2,97 @@
 #'
 #' Bundle the application and deploy it to <https://shinyapps.io>.
 #'
+#' Three environment variables are required:
+#'
+#'   * `RSCONNECT_ACCOUNT_NAME`,
+#'   * `RSCONNECT_ACCOUNT_TOKEN`, and
+#'   * `RSCONNECT_ACCOUNT_SECRET`.
+#'
+#' Store them in an untracked top-level .Renviron file.
+#'
 #' @usage
 #' ## In interactive sessions
-#' .pub()
+#' .pub(...)
 #'
-#' Three environment variables are required (see below). Store them in an
-#' untracked top-level .Renviron file.
+#' ## In non-interactive session
+#' publish(
+#'   region       = c("dev", "prod"),
+#'   account      = "lavoue",
+#'   version      = default_version[["number"]],
+#'   release_date = default_version[["release_date"]]
+#' )
+#'
+#' @param region A character string. It must be equal to `"prod"`, or `"dev"`.
+#'
+#' @param account A non-empty and non-NA character string.
+#'
+#' @param version A non-empty and non-NA character string.
+#'
+#' @param release_date A non-empty and non-NA character string.
+#'
+#' @returns The output of [rsconnect::deployApp()].
 #'
 #' @author Jean-Mathieu Potvin (<jeanmathieupotvin@@ununoctium.dev>)
+#'
+#' @seealso
+#' [rsconnect::deployApp()],
+#' [rsconnect::setAccountInfo()]
+#'
+#' @examples
+#' publish("dev")
+#' publish("prod")
+#'
+#' @export
+publish <- function(
+    region       = c("dev", "prod"),
+    account      = "lavoue",
+    version      = default_version[["number"]],
+    release_date = default_version[["release_date"]])
+{
+    region <- match.arg(region)
 
-rsconnect::setAccountInfo(
-    server = "shinyapps.io",
-    name   = Sys.getenv("RSCONNECT_ACCOUNT_NAME"),
-    token  = Sys.getenv("RSCONNECT_ACCOUNT_TOKEN"),
-    secret = Sys.getenv("RSCONNECT_ACCOUNT_SECRET"))
+    stopifnot({
+        is_chr1(account)
+        is_chr1(version)
+        is_chr1(release_date)
+    })
 
-rsconnect::deployApp(
-    appId          = 13889847L,
-    appName        = "tool1",
-    appTitle       = "Tool1: Data Interpretation for One Similar Exposure Group (SEG)",
-    appMode        = "shiny",
-    appVisibility  = "public",
-    logLevel       = "verbose",
-    launch.browser = FALSE,
-    lint           = FALSE,
-    forceUpdate    = FALSE,
-    metadata       = list(
-        version_number       = default_version[["number"]],
-        version_release_date = default_version[["release_date"]],
-        license              = "MIT + file LICENSE",
-        bug_reports          = "https://github.com/webexpo/app-tool1/issues",
-        encoding             = "UTF-8",
-        language             = "en"
+    cat(sprintf("Deploying app to the '%s' region.", region), sep = "\n")
+
+    rsconnect::setAccountInfo(
+        server = "shinyapps.io",
+        name   = Sys.getenv("RSCONNECT_ACCOUNT_NAME"),
+        token  = Sys.getenv("RSCONNECT_ACCOUNT_TOKEN"),
+        secret = Sys.getenv("RSCONNECT_ACCOUNT_SECRET")
     )
-)
+
+    # Determine the remote instance to replace.
+    app_to_deploy <- switch(region,
+        prod = c(id = 13889847L, name = "tool1"),
+        dev  = c(id = 14521166L, name = "tool1-beta")
+    )
+
+    return(
+        rsconnect::deployApp(
+            account        = account,
+            appId          = app_to_deploy[["id"]],
+            appName        = app_to_deploy[["name"]],
+            appTitle       = "Tool1: Data Interpretation for One Similar Exposure Group (SEG)",
+            appMode        = "shiny",
+            appVisibility  = "public",
+            logLevel       = "verbose",
+            launch.browser = FALSE,
+            lint           = FALSE,
+            forceUpdate    = FALSE,
+            metadata       = list(
+                region               = region,
+                version_number       = version,
+                version_release_date = release_date,
+                license              = "MIT + file LICENSE",
+                bug_reports          = "https://github.com/webexpo/app-tool1/issues",
+                encoding             = "UTF-8",
+                language             = "en"
+            )
+        )
+    )
+}

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,10 @@
   of times `bslib::update_tooltip()` is called has been reduced. All outputs
   are cached.
 
+* Development script `R/publish.R` was refactored into a `publish()` function.
+  It can either publish a development version or an official version of Tool 1.
+  See `README.md` for details.
+
 ## Fixes
 
 * Estimates boxes now properly overflow vertically as a whole (with only one

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,17 +10,20 @@
   text labels.
 
 * This changelog is now accessible directly from a link included in the footer
-  of the sidebar and Frequently Asked Questions modal.
+  of the Calculation Parameters sidebar and Frequently Asked Questions modal.
 
 ## Server Changes
 
 * The implementation of `ui_title()` was revamped and optimized. The objective
-  was to create a responsive Title Bar module. It now leverages
+  was to create a responsive Title Bar module leveraging
   [Bootrap 5 Navbar classes](https://getbootstrap.com/docs/5.3/components/navbar/).
 
-* The implementation of `server_title()` is now a little bit faster. There are
-  less calls to `bslib::update_tooltip()` and all static outputs are now cached.
+* The implementation of `server_title()` is now a little bit faster. The number
+  of times `bslib::update_tooltip()` is called has been reduced. All outputs
+  are cached.
 
 ## Fixes
 
-None.
+* Estimates boxes now properly overflow vertically as a whole (with only one
+  scrollbar) and not as two separate elements. The latter was confusing on
+  smaller screens.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,23 @@
+# Tool 1 version `4.1.0` (In development)
+
+## User Visible Changes
+
+* Tool 1 is now mobile-friendly and should work with a wide variety of screens,
+  including smaller ones. A minimum width of `400` pixels is strongly
+  recommended.
+
+* The title bar is now slightly smaller, and has more intuitive buttons with
+  text labels.
+
+## Server Changes
+
+* The implementation of `ui_title()` was revamped and optimized. The objective
+  was to create a responsive Title Bar module. It now leverages
+  [Bootrap 5 Navbar classes](https://getbootstrap.com/docs/5.3/components/navbar/).
+
+* The implementation of `server_title()` is now a little bit faster. There are
+  less calls to `bslib::update_tooltip()` and all static outputs are now cached.
+
+## Fixes
+
+None.

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,9 @@
 * The title bar is now slightly smaller, and has more intuitive buttons with
   text labels.
 
+* This changelog is now accessible directly from a link included in the footer
+  of the sidebar and Frequently Asked Questions modal.
+
 ## Server Changes
 
 * The implementation of `ui_title()` was revamped and optimized. The objective

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,3 +27,7 @@
 * Estimates boxes now properly overflow vertically as a whole (with only one
   scrollbar) and not as two separate elements. The latter was confusing on
   smaller screens.
+
+* Message boxes included in the Calculation Parameters sidebar now properly
+  grow and shrink on all screens. They no longer collapse to a single line
+  with a width equal to `2px` (top and bottom borders).

--- a/R/global.R
+++ b/R/global.R
@@ -89,6 +89,7 @@ default_maintainers_emails <- c(
 
 # Default URLs to various resources.
 default_urls <- list(
+    news            = "https://github.com/webexpo/tool1/blob/main/NEWS.md",
     code            = "https://github.com/webexpo/tool1",
     aiha            = "https://www.aiha.org",
     ununoctium      = "https://ununoctium.dev",

--- a/R/global.R
+++ b/R/global.R
@@ -60,7 +60,7 @@ shiny::shinyOptions(
 # Constants --------------------------------------------------------------------
 
 # Default version/release to display in footers.
-default_version <- c(number = "4.0.0", release_date = "2025-04-11")
+default_version <- c(number = "4.1.0", release_date = "2025-04-14")
 
 # Default language.
 default_lang <- transltr::language_source_get()

--- a/R/global.R
+++ b/R/global.R
@@ -60,7 +60,7 @@ shiny::shinyOptions(
 # Constants --------------------------------------------------------------------
 
 # Default version/release to display in footers.
-default_version <- c(number = "4.1.0", release_date = "2025-04-15")
+default_version <- c(number = "4.1.0", release_date = "2025-04-16")
 
 # Default language.
 default_lang <- transltr::language_source_get()

--- a/R/global.R
+++ b/R/global.R
@@ -60,7 +60,7 @@ shiny::shinyOptions(
 # Constants --------------------------------------------------------------------
 
 # Default version/release to display in footers.
-default_version <- c(number = "4.1.0", release_date = "2025-04-14")
+default_version <- c(number = "4.1.0", release_date = "2025-04-15")
 
 # Default language.
 default_lang <- transltr::language_source_get()

--- a/R/ui-banner.R
+++ b/R/ui-banner.R
@@ -66,7 +66,7 @@ ui_banner <- function(id) {
                 role  = "alert",
 
                 tags$div(
-                    class = "fs-4",
+                    class = "fs-4 text-center",
 
                     tags$span(
                         class = "pe-2",

--- a/R/ui-footer.R
+++ b/R/ui-footer.R
@@ -51,7 +51,10 @@ server_footer <- function(id, lang) {
                 translate(lang = lang(), "Tool 1"),
                 translate(lang = lang(), "version"),
                 ui_link(default_urls$code, default_version[["number"]]),
-                sprintf("(%s).", default_version[["release_date"]])
+                sprintf("(%s)", default_version[["release_date"]]),
+                bsicons::bs_icon("dot", ally = "deco"),
+                ui_link(default_urls$news, "Changelog"),
+                "."
             )
         }) |>
         shiny::bindCache(lang())

--- a/R/ui-footer.R
+++ b/R/ui-footer.R
@@ -53,8 +53,7 @@ server_footer <- function(id, lang) {
                 ui_link(default_urls$code, default_version[["number"]]),
                 sprintf("(%s)", default_version[["release_date"]]),
                 bsicons::bs_icon("dot", ally = "deco"),
-                ui_link(default_urls$news, "Changelog"),
-                "."
+                ui_link(default_urls$news, "Changelog")
             )
         }) |>
         shiny::bindCache(lang())

--- a/R/ui-modal-faq.R
+++ b/R/ui-modal-faq.R
@@ -122,7 +122,7 @@ ui_modal_faq <- function(id) {
     # used to id the currently opened modal.
     # Only shown on larger screens (>= 992px).
     btn_close <- tags$button(
-        class             = "btn btn-outline-secondary app-btn d-none d-lg-block",
+        class             = "btn btn-outline-secondary app-btn",
         type              = "button",
         "data-bs-dismiss" = "modal",
         bsicons::bs_icon("x-lg", a11y = "sem")

--- a/R/ui-modal-faq.R
+++ b/R/ui-modal-faq.R
@@ -120,8 +120,9 @@ ui_modal_faq <- function(id) {
     # modal_id according to Bootstrap. This
     # is a little weird, but this value is
     # used to id the currently opened modal.
+    # Only shown on larger screens (>= 992px).
     btn_close <- tags$button(
-        class             = "btn btn-outline-secondary app-btn",
+        class             = "btn btn-outline-secondary app-btn d-none d-lg-block",
         type              = "button",
         "data-bs-dismiss" = "modal",
         bsicons::bs_icon("x-lg", a11y = "sem")

--- a/R/ui-modal-faq.R
+++ b/R/ui-modal-faq.R
@@ -187,7 +187,7 @@ ui_modal_faq <- function(id) {
                 # It is postioned at the bottom of the screen unless
                 # classes modal-dialog-centered and mt-5 are set.
                 tags$div(
-                    class = "modal-dialog modal-dialog-centered modal-dialog-scrollable modal-xl mt-5",
+                    class = "modal-dialog modal-dialog-scrollable modal-xl",
 
                     tags$div(
                         # Class app-navset-bar-fix is a special
@@ -198,25 +198,39 @@ ui_modal_faq <- function(id) {
                         class = "modal-content app-navset-bar-fix",
 
                         # Modal's body.
-                        # Optional class modal-body is not included for
-                        # seamless integration of a bslib::navset_bar().
-                        bslib::navset_bar(
-                            id       = ns("panel_active"),
-                            selected = ns("panel_intro"),
-                            title    = shiny::textOutput(ns("title"), tags$span),
-                            footer   = tags$div(
-                                class = "border-top py-3",
-                                ui_footer(ns("footer"))
-                            ),
+                        tags$div(
+                            class = "modal-body p-0",
 
-                            bslib::nav_spacer(),
+                            bslib::navset_bar(
+                                id       = ns("panel_active"),
+                                selected = ns("panel_intro"),
+                                title    = shiny::textOutput(ns("title"), tags$span),
+                                footer   = tags$div(
+                                    class = "border-top py-3",
+                                    ui_footer(ns("footer"))
+                                ),
 
-                            panel_intro,
-                            panel_parameters,
-                            panel_usage,
-                            panel_metho,
+                                bslib::nav_spacer(),
 
-                            bslib::nav_item(btn_close)
+                                panel_intro,
+                                panel_parameters,
+                                panel_usage,
+                                panel_metho,
+
+                                # Close button.
+                                bslib::nav_item(
+                                    # Extra padding to separate
+                                    # button from other nav items.
+
+                                    # Only shown on larger screens (>= 992px).
+                                    tags$div(class = "d-none d-lg-block"),
+
+                                    # Only shown on smaller screens (<= 992px).
+                                    tags$div(class = "d-lg-none mt-2"),
+
+                                    btn_close
+                                )
+                            )
                         )
                     )
                 )
@@ -311,6 +325,7 @@ ui_panel_intro_accordion <- function(lang = "") {
         open     = FALSE,
         multiple = FALSE,
         class    = "accordion-flush app-accordion-active-bold",
+        style    = "overflow: auto;",
 
         ## Panel: What is Tool 1? ----------------------------------------------
 
@@ -425,6 +440,7 @@ ui_panel_parameters_accordion <- function(lang = "") {
         open     = FALSE,
         multiple = FALSE,
         class    = "accordion-flush app-accordion-active-bold",
+        style    = "overflow: auto;",
 
         ## Panel: How should measurements be formatted? ------------------------
 
@@ -446,7 +462,7 @@ ui_panel_parameters_accordion <- function(lang = "") {
             ),
 
             tags$ol(
-                class = "list-group list-group-flush px-5",
+                class = "list-group list-group-flush px-2",
                 style = "text-align: justify;",
 
                 tags$li(
@@ -545,7 +561,7 @@ ui_panel_parameters_accordion <- function(lang = "") {
             ")),
 
             tags$ol(
-                class = "list-group list-group-flush px-5",
+                class = "list-group list-group-flush px-2",
                 style = "text-align: justify;",
 
                 tags$li(
@@ -588,7 +604,7 @@ ui_panel_parameters_accordion <- function(lang = "") {
             ")),
 
             tags$ul(
-                class = "list-group list-group-flush px-5",
+                class = "list-group list-group-flush px-2",
 
                 tags$li(
                     class = "list-group-item",
@@ -636,6 +652,7 @@ ui_panel_usage_accordion <- function(lang = "") {
         open     = FALSE,
         multiple = FALSE,
         class    = "accordion-flush app-accordion-active-bold",
+        style    = "overflow: auto;",
 
         ## Panel: Why is there no shown output initially? ----------------------
 
@@ -659,7 +676,7 @@ ui_panel_usage_accordion <- function(lang = "") {
             ")),
 
             tags$ol(
-                class = "list-group list-group-flush px-5",
+                class = "list-group list-group-flush px-2",
 
                 tags$li(
                     class = "list-group-item",
@@ -767,6 +784,7 @@ ui_panel_metho_accordion <- function(lang = "") {
         open     = FALSE,
         multiple = FALSE,
         class    = "accordion-flush app-accordion-active-bold",
+        style    = "overflow: auto;",
 
         ## Panel: What is the statistical approach used by Tool 1? -------------
 
@@ -782,7 +800,7 @@ ui_panel_metho_accordion <- function(lang = "") {
             ")),
 
             tags$ul(
-                class = "list-group list-group-flush px-5",
+                class = "list-group list-group-flush px-2",
 
                 tags$li(
                     class = "list-group-item",

--- a/R/ui-modal-faq.R
+++ b/R/ui-modal-faq.R
@@ -104,13 +104,15 @@ ui_modal_faq <- function(id) {
         "data-bs-target" = paste0("#", modal_id),
 
         tags$button(
-            class = "btn btn-outline-secondary app-btn",
+            class = "nav-link",
             type  = "button",
-            bsicons::bs_icon("info-circle-fill", a11y = "sem")
-        ) |> bslib::tooltip(
-            id        = ns("btn_faq_tooltip"),
-            placement = "bottom",
-            ""
+
+            tags$span(
+                class = "pe-1",
+                bsicons::bs_icon("info-circle-fill", a11y = "sem")
+            ),
+
+            shiny::textOutput(ns("btn_open_text"), tags$span)
         )
     )
 
@@ -119,10 +121,10 @@ ui_modal_faq <- function(id) {
     # is a little weird, but this value is
     # used to id the currently opened modal.
     btn_close <- tags$button(
-        class             = "btn btn-outline-secondary app-btn-small",
+        class             = "btn btn-outline-secondary app-btn",
         type              = "button",
         "data-bs-dismiss" = "modal",
-        bsicons::bs_icon("x-square-fill", a11y = "sem")
+        bsicons::bs_icon("x-lg", a11y = "sem")
     )
 
     panel_intro <- bslib::nav_panel(
@@ -230,6 +232,11 @@ server_modal_faq <- function(id, lang) {
     server <- \(input, output, session) {
         server_footer("footer", lang)
 
+        output$btn_open_text <- shiny::renderText({
+            translate(lang = lang(), "FAQ")
+        }) |>
+        shiny::bindCache(lang())
+
         output$title <- shiny::renderText({
             translate(lang = lang(), "Frequently Asked Questions")
         }) |>
@@ -285,18 +292,6 @@ server_modal_faq <- function(id, lang) {
             ui_panel_metho_accordion(lang())
         }) |>
         shiny::bindCache(lang())
-
-        # Translate elements not rendered
-        # with a shiny::render*() function.
-        shiny::observe({
-            lang <- lang()
-
-            bslib::update_tooltip("btn_faq_tooltip", translate(lang = lang, "
-                Get more information on this application and learn how to
-                use it properly.
-            "))
-        }) |>
-        shiny::bindEvent(lang())
 
         return(invisible())
     }

--- a/R/ui-panel-arithmetic-mean.R
+++ b/R/ui-panel-arithmetic-mean.R
@@ -141,37 +141,33 @@ ui_panel_arithmetic_mean <- function(id) {
             )
         ),
 
-        # Estimates of the underlying distribution parameters.
         bslib::card_body(
-            fillable = FALSE,
+            # Estimates of the underlying distribution parameters.
+            tags$div(
+                tags$h3(
+                    class = "fs-5",
+                    shiny::textOutput(ns("estimates_params_title"), tags$span)
+                ),
 
-            bslib::card_title(
-                container = tags$h3,
-                class     = "mb-2 fs-5",
-                shiny::textOutput(ns("estimates_params_title"), tags$span)
+                shiny::uiOutput(
+                    outputId   = ns("estimates_params"),
+                    container = tags$ul,
+                    class     = "list-group list-group-flush"
+                )
             ),
 
-            shiny::uiOutput(
-                outputId   = ns("estimates_params"),
-                container = tags$ul,
-                class     = "list-group list-group-flush"
-            )
-        ),
+            # Estimate of the arithmetic mean.
+            tags$div(
+                tags$h3(
+                    class = "fs-5",
+                    shiny::textOutput(ns("estimates_mean_title"), tags$span)
+                ),
 
-        # Estimate of the arithmetic mean.
-        bslib::card_body(
-            fillable = FALSE,
-
-            bslib::card_title(
-                container = tags$h3,
-                class     = "mb-2 fs-5",
-                shiny::textOutput(ns("estimates_mean_title"), tags$span)
-            ),
-
-            shiny::uiOutput(
-                outputId   = ns("estimates_mean"),
-                container = tags$ul,
-                class     = "list-group list-group-flush"
+                shiny::uiOutput(
+                    outputId   = ns("estimates_mean"),
+                    container = tags$ul,
+                    class     = "list-group list-group-flush"
+                )
             )
         ),
 

--- a/R/ui-panel-exceedance-fraction.R
+++ b/R/ui-panel-exceedance-fraction.R
@@ -126,37 +126,33 @@ ui_panel_exceedance_fraction <- function(id) {
             )
         ),
 
-        # Estimates of the underlying distribution parameters.
         bslib::card_body(
-            fillable = FALSE,
+            # Estimates of the underlying distribution parameters.
+            tags$div(
+                tags$h3(
+                    class = "fs-5",
+                    shiny::textOutput(ns("estimates_params_title"), tags$span)
+                ),
 
-            bslib::card_title(
-                container = tags$h3,
-                class     = "mb-2 fs-5",
-                shiny::textOutput(ns("estimates_params_title"), tags$span)
+                shiny::uiOutput(
+                    outputId   = ns("estimates_params"),
+                    container = tags$ul,
+                    class     = "list-group list-group-flush"
+                )
             ),
 
-            shiny::uiOutput(
-                outputId   = ns("estimates_params"),
-                container = tags$ul,
-                class     = "list-group list-group-flush"
-            )
-        ),
+            # Estimate of the exceedance fraction.
+            tags$div(
+                tags$h3(
+                    class = "fs-5",
+                    shiny::textOutput(ns("estimates_fraction_title"), tags$span)
+                ),
 
-        # Estimate of the exceedance fraction.
-        bslib::card_body(
-            fillable = FALSE,
-
-            bslib::card_title(
-                container = tags$h3,
-                class     = "mb-2 fs-5",
-                shiny::textOutput(ns("estimates_fraction_title"), tags$span)
-            ),
-
-            shiny::uiOutput(
-                outputId   = ns("estimates_fraction"),
-                container = tags$ul,
-                class     = "list-group list-group-flush"
+                shiny::uiOutput(
+                    outputId   = ns("estimates_fraction"),
+                    container = tags$ul,
+                    class     = "list-group list-group-flush"
+                )
             )
         ),
 

--- a/R/ui-panel-percentiles.R
+++ b/R/ui-panel-percentiles.R
@@ -122,37 +122,33 @@ ui_panel_percentiles <- function(id) {
             )
         ),
 
-        # Estimates of the underlying distribution parameters.
         bslib::card_body(
-            fillable = FALSE,
+            # Estimates of the underlying distribution parameters.
+            tags$div(
+                tags$h3(
+                    class = "fs-5",
+                    shiny::textOutput(ns("estimates_params_title"), tags$span)
+                ),
 
-            bslib::card_title(
-                container = tags$h3,
-                class     = "mb-2 fs-5",
-                shiny::textOutput(ns("estimates_params_title"), tags$span)
+                shiny::uiOutput(
+                    outputId   = ns("estimates_params"),
+                    container = tags$ul,
+                    class     = "list-group list-group-flush"
+                )
             ),
 
-            shiny::uiOutput(
-                outputId   = ns("estimates_params"),
-                container = tags$ul,
-                class     = "list-group list-group-flush"
-            )
-        ),
+            # Estimate of the percentile.
+            tags$div(
+                tags$h3(
+                    class = "fs-5",
+                    shiny::textOutput(ns("estimates_percentile_title"), tags$span)
+                ),
 
-        # Estimate of the percentile.
-        bslib::card_body(
-            fillable = FALSE,
-
-            bslib::card_title(
-                container = tags$h3,
-                class     = "mb-2 fs-5",
-                shiny::textOutput(ns("estimates_percentile_title"), tags$span)
-            ),
-
-            shiny::uiOutput(
-                outputId   = ns("estimates_percentile"),
-                container = tags$ul,
-                class     = "list-group list-group-flush"
+                shiny::uiOutput(
+                    outputId   = ns("estimates_percentile"),
+                    container = tags$ul,
+                    class     = "list-group list-group-flush"
+                )
             )
         ),
 

--- a/R/ui-sidebar.R
+++ b/R/ui-sidebar.R
@@ -342,7 +342,8 @@ server_sidebar <- function(id, lang, panel_active) {
             bslib::update_tooltip("data_tooltip", translate(lang = lang, "
                 The measurement dataset. There must be one value per line. Values
                 can be censored to the left (<), to the right (>), or interval
-                censored ([X-Y]).
+                censored ([X-Y]). For more information, see the Calculation
+                Parameters section in Frequently Asked Questions (FAQ) above.
             "))
 
             bslib::update_tooltip("submit_btn_tooltip", translate(lang = lang, "

--- a/R/ui-sidebar.R
+++ b/R/ui-sidebar.R
@@ -169,23 +169,28 @@ ui_sidebar <- function(id) {
 
         # Warnings -------------------------------------------------------------
 
-        # Measurements' numbering format.
-        bslib::card(
-            id    = ns("data_format_card"),
-            class = "border-warning bg-warning-subtle text-center small",
+        # The <div> ensures that cards grow as expected
+        # (without having to deal with fill and fillable
+        # details) once they are updated by the server.
+        tags$div(
+            # Measurements' numbering format.
+            bslib::card(
+                id    = ns("data_format_card"),
+                class = "border-warning bg-warning-subtle small",
 
-            bslib::card_body(
-                shiny::textOutput(ns("data_format_card_text"), tags$span)
-            )
-        ),
+                bslib::card_body(
+                    shiny::textOutput(ns("data_format_card_text"), tags$p)
+                )
+            ),
 
-        # Hidden inputs.
-        bslib::card(
-            id    = ns("hidden_inputs_card"),
-            class = "border-info bg-info-subtle text-center small",
+            # Hidden inputs.
+            bslib::card(
+                id    = ns("hidden_inputs_card"),
+                class = "border-info bg-info-subtle small mb-0",
 
-            bslib::card_body(
-                shiny::textOutput(ns("hidden_inputs_card_text"), tags$span)
+                bslib::card_body(
+                    shiny::textOutput(ns("hidden_inputs_card_text"), tags$p)
+                )
             )
         ),
 

--- a/R/ui-title.R
+++ b/R/ui-title.R
@@ -59,18 +59,15 @@
 #'
 #' @seealso
 #' [Bootrap 5 Navbars](https://getbootstrap.com/docs/5.3/components/navbar/),
-#' [Bootstrap 5 Dropdowns](https://getbootstrap.com/docs/5.3/components/dropdowns)
+#' [Bootstrap 5 Dropdowns](https://getbootstrap.com/docs/5.3/components/dropdowns),
+#' [Bootstrap 5 Breakpoints](https://getbootstrap.com/docs/5.3/layout/breakpoints/)
 #'
 #' @rdname ui-title
 #'
 #' @export
 ui_title <- function(id) {
     ns <- shiny::NS(id)
-
-    submit_bug_mailto <- paste0(
-        "mailto:",
-        paste0(default_maintainers_emails, collapse = ",")
-    )
+    nav_id <- ns("navbar_nav")
 
     # Bootstrap recommends to mark elements of dropdowns
     # within <li> elements. Each <li> encapsulate a link
@@ -105,178 +102,195 @@ ui_title <- function(id) {
         .cssSelector    = "a"
     )
 
-    ui <- list(
-        # Branding (Logo and title) --------------------------------------------
-
-        tags$div(
-            class = "navbar-brand py-0",
-
-            tags$a(
-                style    = "text-decoration: none;",
-                href     = "",
-                hreflang = default_lang,
-                target   = "_self",
-
-                # Height of logo is manually set
-                # equal to the height of buttons.
-                tags$img(
-                    id     = ns("logo"),
-                    src    = "images/logo-400x400.png",
-                    alt    = "Logo",
-                    width  = "400px",
-                    height = "400px",
-                    style  = "height: 40px;",
-                    class  = "w-auto pe-1"
-                )
-            ),
-
-            htmltools::tagAppendAttributes(
-                class = "fw-bold",
-                shiny::textOutput(ns("name"), tags$span)
-            ),
-
-            # Title is only shown on screens
-            # larger than >=1500 pixels.
-            tags$span(
-                class = "app-large-screen-only text-muted",
-
-                ":",
-                shiny::textOutput(ns("title"), tags$span),
-                "(SEG)"
-            )
-        ),
-
-        # Navigation Bar (Buttons) ---------------------------------------------
-
-        tags$div(
-            class = "navbar-nav",
-
-            ## Languages -------------------------------------------------------
-
-            # See @note above on dropdowns and tooltips.
-            # bslib::nav_menu() cannot be used outside of
-            # a bslib::navset.
+    return(
+        list(
+            # Branding (Logo and title) ----------------------------------------
 
             tags$div(
-                id = ns("btn_langs"),
-
-                # Display inline-block is required to align
-                # the dropdown button with other buttons on
-                # the vertical axis.
-                class = "nav-link d-inline-block dropdown py-0",
-
-                tags$button(
-                    class            = "btn btn-outline-secondary app-btn dropdown-toggle",
-                    type             = "button",
-                    "data-bs-toggle" = "dropdown",
-                    bsicons::bs_icon("translate", a11y = "none")
-                ),
-
-                htmltools::tagSetChildren(
-                    tags$ul(class = "dropdown-menu"),
-                    list = btn_langs_choices
-                )
-            ) |> bslib::tooltip(
-                id        = ns("btn_langs_tooltip"),
-                placement = "left",
-                ""
-            ),
-
-            ## Frequently Asked Questions --------------------------------------
-
-            tags$div(
-                class = "nav-link py-0",
-                ui_modal_faq(ns("faq"))
-            ),
-
-            ## Dark Mode -------------------------------------------------------
-
-            tags$div(
-                class = "nav-link py-0",
-
-                shiny::actionButton(
-                    class   = "btn btn-outline-secondary app-btn",
-                    inputId = ns("btn_color_mode"),
-                    label   = bsicons::bs_icon("moon-fill", a11y = "none"),
-                ) |>
-                bslib::tooltip(
-                    id        = ns("btn_color_mode_tooltip"),
-                    placement = "bottom",
-                    ""
-                )
-            ),
-
-            ## Links -----------------------------------------------------------
-
-            # See @note above on dropdowns and tooltips.
-            tags$div(
-                id = ns("btn_links"),
-
-                # Display inline-block is required to align
-                # the dropdown button with other buttons on
-                # the vertical axis.
-                class = "nav-link d-inline-block dropdown py-0",
-
-                tags$button(
-                    class            = "btn btn-outline-secondary app-btn dropdown-toggle",
-                    type             = "button",
-                    "data-bs-toggle" = "dropdown",
-                    bsicons::bs_icon("link", a11y = "none")
-                ),
-
-                shiny::uiOutput(
-                    ns("btn_links_choices"),
-                    container = tags$ul,
-                    class     = "dropdown-menu"
-                )
-            ) |> bslib::tooltip(
-                id        = ns("btn_links_tooltip"),
-                placement = "left",
-                ""
-            ),
-
-            ## Submit Bug ------------------------------------------------------
-
-            tags$div(
-                class = "nav-link py-0",
+                class = "navbar-brand py-0",
 
                 tags$a(
-                    class  = "btn btn-outline-secondary app-btn",
-                    href   = submit_bug_mailto,
-                    target = "_blank",
-                    bsicons::bs_icon("bug-fill", a11y = "none")
-                ) |>
-                bslib::tooltip(
-                    id        = ns("btn_bug_tooltip"),
-                    placement = "bottom",
-                    ""
+                    style    = "text-decoration: none;",
+                    href     = "",
+                    hreflang = default_lang,
+                    target   = "_self",
+
+                    tags$img(
+                        id     = ns("logo"),
+                        src    = "images/logo-400x400.png",
+                        alt    = "Logo",
+                        width  = "400px",
+                        height = "400px",
+                        style  = "height: 40px;",
+                        class  = "w-auto pe-1"
+                    )
+                ),
+
+                htmltools::tagAppendAttributes(
+                    class = "fw-bolder",
+                    shiny::textOutput(ns("name"), tags$span)
+                ),
+
+                # The full title is only shown on extra extra large
+                # screens (>=1400px). See Bootstrap breakpoints for
+                # more information.
+                tags$span(
+                    class = "d-none d-xxl-inline",
+
+                    ":",
+                    shiny::textOutput(ns("title"), tags$span),
+                    "(SEG)"
                 )
             ),
 
-            ## Source Code -----------------------------------------------------
+            # Menu Button ------------------------------------------------------
 
-            # Padding is removed for last element
-            # for consistency with padding on the
-            # left of the navbar.
+            # Hamburger button to toggle menu.
+            # Only shown on smaller screens (<= 992px).
+            tags$button(
+                class            = "navbar-toggler",
+                type             = "button",
+                "data-bs-toggle" = "collapse",
+                "data-bs-target" = paste0("#", nav_id),
+
+                # Default Boostrap hamburger icon.
+                tags$span(class = "navbar-toggler-icon")
+            ),
+
+            # Navigation Bar ---------------------------------------------------
+
             tags$div(
-                class = "nav-link py-0 pe-0",
+                id    = nav_id,
+                class = "collapse navbar-collapse justify-content-end",
 
-                tags$a(
-                    class  = "btn btn-outline-secondary app-btn",
-                    href   = default_urls$code,
-                    target = "_blank",
-                    bsicons::bs_icon("github", a11y = "none")
-                ) |>
-                bslib::tooltip(
-                    id        = ns("btn_code_tooltip"),
-                    placement = "bottom",
-                    ""
+                tags$ul(
+                    class = "navbar-nav",
+
+                    # Extra padding to separate branding from nav items.
+                    # Only shown on smaller screens (<= 992px).
+                    tags$div(class = "d-lg-none mt-3"),
+
+                    ## Frequently Asked Questions ------------------------------
+
+                    tags$li(
+                        class = "nav-item",
+                        ui_modal_faq(ns("faq"))
+                    ),
+
+                    ## Languages -----------------------------------------------
+
+                    tags$li(
+                        class = "nav-item dropdown",
+
+                        tags$button(
+                            class            = "nav-link dropdown-toggle",
+                            type             = "button",
+                            "data-bs-toggle" = "dropdown",
+
+                            tags$span(
+                                class = "pe-1",
+                                bsicons::bs_icon("translate", a11y = "none")
+                            ),
+
+                            shiny::textOutput(ns("nav_item_language"), tags$span)
+                        ),
+
+                        htmltools::tagSetChildren(
+                            tags$ul(class = "dropdown-menu"),
+                            list = btn_langs_choices
+                        )
+                    ),
+
+                    ## Expostats Links -----------------------------------------
+
+                    tags$li(
+                        class = "nav-item dropdown",
+
+                        tags$button(
+                            class            = "nav-link dropdown-toggle",
+                            type             = "button",
+                            "data-bs-toggle" = "dropdown",
+
+                            tags$span(
+                                class = "pe-1",
+                                bsicons::bs_icon("link", a11y = "none")
+                            ),
+
+                            "Expostats"
+                        ),
+
+                        shiny::uiOutput(
+                            ns("nav_item_expostats_links"),
+                            container = tags$ul,
+                            class     = "dropdown-menu"
+                        )
+                    ),
+
+                    ## Spacers -------------------------------------------------
+
+                    # Vertical bar for larger screens to
+                    # separate buttons from other nav items.
+                    # Only shown on larger screens (>= 992px).
+                    tags$div(class = "d-none d-lg-block vr ms-2 me-3"),
+
+                    # Extra padding to separate buttons from other nav items.
+                    # Only shown on smaller screens (<= 992px).
+                    tags$div(class = "d-lg-none mt-3"),
+
+                    ## Buttons -------------------------------------------------
+
+                    # They are grouped together as a single nav item.
+                    tags$li(
+                        class = "nav-item",
+
+                        ### GitHub ---------------------------------------------
+
+                        tags$a(
+                            class  = "btn btn-outline-secondary app-btn me-2",
+                            href   = default_urls$code,
+                            target = "_blank",
+                            bsicons::bs_icon("github", a11y = "none")
+                        ) |>
+                        bslib::tooltip(
+                            id        = ns("btn_code_tooltip"),
+                            placement = "bottom",
+                            ""
+                        ),
+
+                        ### Submit Bugs ----------------------------------------
+
+                        tags$a(
+                            class  = "btn btn-outline-secondary app-btn me-2",
+                            href   = paste0(
+                                "mailto:",
+                                paste(default_maintainers_emails, collapse = ",")
+                            ),
+                            target = "_blank",
+                            bsicons::bs_icon("bug-fill", a11y = "none")
+                        ) |>
+                        bslib::tooltip(
+                            id        = ns("btn_bug_tooltip"),
+                            placement = "bottom",
+                            ""
+                        ),
+
+                        ### Source Code ----------------------------------------
+
+                        shiny::actionButton(
+                            class   = "btn btn-outline-secondary app-btn",
+                            inputId = ns("btn_color"),
+                            label   = bsicons::bs_icon("moon-fill", a11y = "none")
+                        ) |>
+                        bslib::tooltip(
+                            id        = ns("btn_color_tooltip"),
+                            placement = "bottom",
+                            ""
+                        )
+                    )
                 )
             )
         )
     )
-
-    return(ui)
 }
 
 #' @rdname ui-title
@@ -299,7 +313,12 @@ server_title <- function(id, lang) {
         }) |>
         shiny::bindCache(lang())
 
-        output$btn_links_choices <- shiny::renderUI({
+        output$nav_item_language <- shiny::renderText({
+            translate(lang = lang(), "Language")
+        }) |>
+        shiny::bindCache(lang())
+
+        output$nav_item_expostats_links <- shiny::renderUI({
             lang <- lang()
             links <- list(
                 list(
@@ -338,50 +357,42 @@ server_title <- function(id, lang) {
                     )
                 )
             })
-        })
+        }) |>
+        shiny::bindCache(lang())
 
         # Toggle color mode (light/dark).
         shiny::observe({
             # Icon shown in light mode is the one for dark mode,
             # and vice-versa. Since light is the initial mode,
-            # even values (including 0) of input$btn_color_mode
-            # show icon for dark mode, and odd numbers show the
-            # icon of light mode (each click toggles dark mode).
-            icon <- if (input$btn_color_mode %% 2L == 0L) {
+            # even values (including 0) of input$btn_color show
+            # icon for dark mode, and odd numbers show the icon
+            # of light mode (each click toggles dark mode).
+            icon <- if (input$btn_color %% 2L == 0L) {
                 bsicons::bs_icon("moon-fill", a11y = "none")
             } else {
                 bsicons::bs_icon("sun-fill", a11y = "none")
             }
 
             bslib::toggle_dark_mode()
-            shiny::updateActionButton(session, "btn_color_mode", label = icon)
+            shiny::updateActionButton(session, "btn_color", label = icon)
         }) |>
-        shiny::bindEvent(input$btn_color_mode)
+        shiny::bindEvent(input$btn_color)
 
         # Translate elements not rendered
         # with a shiny::render*() function.
         shiny::observe({
             lang <- lang()
 
-            bslib::update_tooltip("btn_langs_tooltip", translate(lang = lang, "
-                Choose your preferred language.
-            "))
-
-            bslib::update_tooltip("btn_links_tooltip", translate(lang = lang, "
-                Explore Expostats and other tools.
-            "))
-
-            bslib::update_tooltip("btn_color_mode_tooltip", translate(lang = lang, "
-                Choose your preferred color scheme. This is an experimental
-                feature. Contents may not be displayed appropriately.
+            bslib::update_tooltip("btn_code_tooltip", translate(lang = lang, "
+                See the source code of Tool 1 on GitHub.
             "))
 
             bslib::update_tooltip("btn_bug_tooltip", translate(lang = lang, "
-                Submit a bug or provide feedback to the maintainers.
+                Submit a bug or provide feedback to the maintainers by email.
             "))
 
-            bslib::update_tooltip("btn_code_tooltip", translate(lang = lang, "
-                See the source code on GitHub.
+            bslib::update_tooltip("btn_color_tooltip", translate(lang = lang, "
+                Toogle the current color scheme (light or dark).
             "))
         }) |>
         shiny::bindEvent(lang())

--- a/README.md
+++ b/README.md
@@ -139,9 +139,6 @@ We may work on these issues in a near future.
 - Inputs lack robust validation mechanisms and may lead to undefined behavior
   in some cases.
 
-- Tool 1 is not optimized for mobile phones and small screens having a width
-  lower than 500 pixels.
-
 - Accessibility mechanisms
   ([ARIA](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA)) are
   not implemented.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # Tool 1: Data Interpretation for One Similar Exposure Group (SEG)
 
 <!-- badges: start -->
-[![Version](https://img.shields.io/badge/version-4.0.0-blue)](https://github.com/webexpo/app-tool1/releases/tag/v4.1.0)
+[![Version](https://img.shields.io/badge/version-4.1.0-blue)](https://github.com/webexpo/app-tool1/releases/tag/v4.1.0)
 [![Lifecycle](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 [![Location](https://img.shields.io/badge/live-shinyapps.io-5b90bf)](https://lavoue.shinyapps.io/tool1/)
 [![License](https://img.shields.io/badge/license-MIT-orange.svg)](https://github.com/webexpo/tool1/blob/main/LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # Tool 1: Data Interpretation for One Similar Exposure Group (SEG)
 
 <!-- badges: start -->
-[![Version](https://img.shields.io/badge/version-4.0.0-blue)](https://github.com/webexpo/app-tool1/releases/tag/v4.0.0)
+[![Version](https://img.shields.io/badge/version-4.0.0-blue)](https://github.com/webexpo/app-tool1/releases/tag/v4.1.0)
 [![Lifecycle](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 [![Location](https://img.shields.io/badge/live-shinyapps.io-5b90bf)](https://lavoue.shinyapps.io/tool1/)
 [![License](https://img.shields.io/badge/license-MIT-orange.svg)](https://github.com/webexpo/tool1/blob/main/LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -59,10 +59,16 @@ This sources `.scripts/run.R`. See this script for details.
 ## Deploy
 
 Tool 1 is deployed to [shinyapps.io](https://lavoue.shinyapps.io/tool1).
-To deploy a new version, call
+To deploy a new version, call `.pub()`.
 
 ```r
+# Deploy a beta version (useful for testing purposes).
+# It is publicly accessible at https://lavoue.shinyapps.io/tool1-beta/.
 .pub()
+
+# Deploy an official version.
+# It is publicly accessible at https://lavoue.shinyapps.io/tool1/.
+.pub("prod")
 ```
 
 This sources `.scripts/publish.R`. See this script for details.

--- a/README.md
+++ b/README.md
@@ -95,17 +95,16 @@ to support multiple languages. Translations (and related metadata) are stored
 in `intl/`. To update its content, call
 
 ```r
-.intl()
+.find()
 ```
 
 This sources `.scripts/find-text.R` and updates all underlying
 translations files. See that script for details.
 
 Tool 1 further supports translation of ordinal numbers. Each supported
-language requires an `ordinal_rules_*()` function. For example, English
-has its own  `ordinal_rules_english()` function implementing grammar
-rules for English ordinal numbers. See `R/helpers-translate.R` for more
-information.
+language requires an `ordinal_rules_<lang>()` function. For example, the
+`ordinal_rules_english()` function implements grammar rules for English
+ordinal numbers. See `R/helpers-translate.R` for more information.
 
 ### Warning
 

--- a/app.R
+++ b/app.R
@@ -41,9 +41,13 @@
 #' @author Jean-Mathieu Potvin (<jeanmathieupotvin@@ununoctium.dev>)
 
 ui <- bslib::page_sidebar(
-    theme   = bslib::bs_theme(5L, "shiny"),
-    title   = ui_title("layout_title"),
-    sidebar = ui_sidebar("layout_sidebar"),
+    # lang and window_title are both updated
+    # by server() based on the chosen lang.
+    lang         = default_lang,
+    window_title = "Expostats - Tool 1",
+    theme        = bslib::bs_theme(5L, "shiny"),
+    title        = ui_title("layout_title"),
+    sidebar      = ui_sidebar("layout_sidebar"),
 
     tags$head(
         tags$link(
@@ -128,7 +132,7 @@ server <- function(input, output, session) {
 
         return(lang)
     }) |>
-    shiny::bindEvent(session$clientData$url_search)
+    shiny::bindEvent(session$clientData$url_search, once = TRUE)
 
     data_sample <- shiny::reactive({
         parameters <- parameters()
@@ -194,15 +198,17 @@ server <- function(input, output, session) {
     shiny::observe({
         lang <- lang()
 
-        # Update the window's title (what the browser's tab displays).
-        session$sendCustomMessage("update_page_lang", lang)
+        if (lang != default_lang) {
+            # Update the window's title (what the browser's tab displays).
+            session$sendCustomMessage("update_page_lang", lang)
 
-        # Update the lang attribute of the root <html> tag.
-        session$sendCustomMessage(
-            "update_window_title",
-            sprintf("Expostats - %s", translate(lang = lang, "Tool 1")))
+            # Update the lang attribute of the root <html> tag.
+            session$sendCustomMessage(
+                "update_window_title",
+                sprintf("Expostats - %s", translate(lang = lang, "Tool 1")))
+        }
     }) |>
-    shiny::bindEvent(lang())
+    shiny::bindEvent(lang(), once = TRUE)
 
     # Modules ------------------------------------------------------------------
 

--- a/intl/_translator.yml
+++ b/intl/_translator.yml
@@ -34,7 +34,7 @@ Texts:
       - !<Location>
         Identifier: 1a6a68b:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 822, Col 21 @ Ln 824, Col 14
+        Ranges: Ln 817, Col 21 @ Ln 819, Col 14
   - !<Text>
     Identifier: 67c3cba
     Algorithm: sha1
@@ -46,7 +46,7 @@ Texts:
       - !<Location>
         Identifier: 67c3cba:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 778, Col 21 @ Ln 780, Col 14
+        Ranges: Ln 773, Col 21 @ Ln 775, Col 14
   - !<Text>
     Identifier: 4e2a12c
     Algorithm: sha1
@@ -131,7 +131,7 @@ Texts:
       - !<Location>
         Identifier: f6e929e:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 350, Col 21 @ Ln 354, Col 22
+        Ranges: Ln 345, Col 21 @ Ln 349, Col 22
   - !<Text>
     Identifier: 73dff8f
     Algorithm: sha1
@@ -143,7 +143,7 @@ Texts:
       - !<Location>
         Identifier: 73dff8f:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 544, Col 21 @ Ln 544, Col 75
+        Ranges: Ln 539, Col 21 @ Ln 539, Col 75
   - !<Text>
     Identifier: 6aff6b7
     Algorithm: sha1
@@ -158,7 +158,7 @@ Texts:
       - !<Location>
         Identifier: 6aff6b7:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 782, Col 20 @ Ln 786, Col 14
+        Ranges: Ln 777, Col 20 @ Ln 781, Col 14
   - !<Text>
     Identifier: 96d547d
     Algorithm: sha1
@@ -245,24 +245,12 @@ Texts:
         Identifier: 745ebd1:l1
         Path: ./R/ui-modal-faq.R
         Ranges:
-          - Ln 244, Col 13 @ Ln 244, Col 62
-          - Ln 446, Col 37 @ Ln 446, Col 84
+          - Ln 251, Col 13 @ Ln 251, Col 62
+          - Ln 441, Col 37 @ Ln 441, Col 84
       - !<Location>
         Identifier: 745ebd1:l2
         Path: ./R/ui-sidebar.R
         Ranges: Ln 217, Col 13 @ Ln 217, Col 62
-  - !<Text>
-    Identifier: 00650f3
-    Algorithm: sha1
-    Hash: 00650f3ae1a9d101d35a12ffea24b34dc831e016
-    Source Language: en
-    Source Text: Explore Expostats and other tools.
-    Translations: ~
-    Locations:
-      - !<Location>
-        Identifier: 00650f3:l1
-        Path: ./R/ui-title.R
-        Ranges: Ln 358, Col 56 @ Ln 360, Col 14
   - !<Text>
     Identifier: 8f7f102
     Algorithm: sha1
@@ -365,7 +353,7 @@ Texts:
       - !<Location>
         Identifier: f7a0860:l3
         Path: ./R/ui-title.R
-        Ranges: Ln 279, Col 13 @ Ln 279, Col 46
+        Ranges: Ln 305, Col 13 @ Ln 305, Col 46
   - !<Text>
     Identifier: 5f52075
     Algorithm: sha1
@@ -449,7 +437,7 @@ Texts:
       - !<Location>
         Identifier: 2052e8c:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 526, Col 21 @ Ln 531, Col 22
+        Ranges: Ln 521, Col 21 @ Ln 526, Col 22
   - !<Text>
     Identifier: '8785301'
     Algorithm: sha1
@@ -485,7 +473,7 @@ Texts:
       - !<Location>
         Identifier: 92193c3:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 322, Col 21 @ Ln 322, Col 61
+        Ranges: Ln 317, Col 21 @ Ln 317, Col 61
   - !<Text>
     Identifier: 179eb27
     Algorithm: sha1
@@ -497,7 +485,7 @@ Texts:
       - !<Location>
         Identifier: 179eb27:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 459, Col 21 @ Ln 459, Col 79
+        Ranges: Ln 454, Col 21 @ Ln 454, Col 79
   - !<Text>
     Identifier: 4a8e3cf
     Algorithm: sha1
@@ -562,9 +550,9 @@ Texts:
         Identifier: dcc46c4:l2
         Path: ./R/ui-modal-faq.R
         Ranges:
-          - Ln 533, Col 38 @ Ln 533, Col 72
-          - Ln 687, Col 42 @ Ln 687, Col 76
-          - Ln 735, Col 38 @ Ln 735, Col 72
+          - Ln 528, Col 38 @ Ln 528, Col 72
+          - Ln 682, Col 42 @ Ln 682, Col 76
+          - Ln 730, Col 38 @ Ln 730, Col 72
   - !<Text>
     Identifier: a32a1f9
     Algorithm: sha1
@@ -630,7 +618,7 @@ Texts:
       - !<Location>
         Identifier: c6394ac:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 518, Col 37 @ Ln 518, Col 83
+        Ranges: Ln 513, Col 37 @ Ln 513, Col 83
       - !<Location>
         Identifier: c6394ac:l2
         Path: ./R/ui-panel-descriptive-statistics.R
@@ -700,7 +688,7 @@ Texts:
       - !<Location>
         Identifier: 962996f:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 794, Col 21 @ Ln 797, Col 22
+        Ranges: Ln 789, Col 21 @ Ln 792, Col 22
   - !<Text>
     Identifier: 00b437c
     Algorithm: sha1
@@ -952,7 +940,7 @@ Texts:
       - !<Location>
         Identifier: f59a9a9:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 750, Col 21 @ Ln 754, Col 22
+        Ranges: Ln 745, Col 21 @ Ln 749, Col 22
   - !<Text>
     Identifier: f111efa
     Algorithm: sha1
@@ -964,7 +952,7 @@ Texts:
       - !<Location>
         Identifier: f111efa:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 364, Col 21 @ Ln 364, Col 77
+        Ranges: Ln 359, Col 21 @ Ln 359, Col 77
   - !<Text>
     Identifier: 6863c44
     Algorithm: sha1
@@ -977,6 +965,18 @@ Texts:
         Identifier: 6863c44:l1
         Path: ./R/ui-sidebar.R
         Ranges: Ln 227, Col 13 @ Ln 227, Col 45
+  - !<Text>
+    Identifier: ecd9787
+    Algorithm: sha1
+    Hash: ecd9787a8a861c1747ffe00be307f5e4a8f32435
+    Source Language: en
+    Source Text: Toogle the current color scheme (light or dark).
+    Translations: ~
+    Locations:
+      - !<Location>
+        Identifier: ecd9787:l1
+        Path: ./R/ui-title.R
+        Ranges: Ln 394, Col 56 @ Ln 396, Col 14
   - !<Text>
     Identifier: f3c096c
     Algorithm: sha1
@@ -1012,7 +1012,7 @@ Texts:
       - !<Location>
         Identifier: 9725731:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 254, Col 13 @ Ln 254, Col 65
+        Ranges: Ln 261, Col 13 @ Ln 261, Col 65
   - !<Text>
     Identifier: f08555d
     Algorithm: sha1
@@ -1028,19 +1028,7 @@ Texts:
       - !<Location>
         Identifier: f08555d:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 828, Col 21 @ Ln 834, Col 22
-  - !<Text>
-    Identifier: 2e77aed
-    Algorithm: sha1
-    Hash: 2e77aedf2ff3773facedbfe2ea1ce6fd6792be69
-    Source Language: en
-    Source Text: See the source code on GitHub.
-    Translations: ~
-    Locations:
-      - !<Location>
-        Identifier: 2e77aed:l1
-        Path: ./R/ui-title.R
-        Ranges: Ln 371, Col 55 @ Ln 373, Col 14
+        Ranges: Ln 823, Col 21 @ Ln 829, Col 22
   - !<Text>
     Identifier: 1fa04de
     Algorithm: sha1
@@ -1069,7 +1057,7 @@ Texts:
       - !<Location>
         Identifier: af71ace:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 600, Col 21 @ Ln 603, Col 22
+        Ranges: Ln 595, Col 21 @ Ln 598, Col 22
   - !<Text>
     Identifier: 5fafea5
     Algorithm: sha1
@@ -1081,7 +1069,7 @@ Texts:
       - !<Location>
         Identifier: 5fafea5:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 722, Col 21 @ Ln 722, Col 85
+        Ranges: Ln 717, Col 21 @ Ln 717, Col 85
   - !<Text>
     Identifier: 99db36b
     Algorithm: sha1
@@ -1117,7 +1105,7 @@ Texts:
       - !<Location>
         Identifier: 9d61612:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 728, Col 21 @ Ln 733, Col 22
+        Ranges: Ln 723, Col 21 @ Ln 728, Col 22
   - !<Text>
     Identifier: e510a31
     Algorithm: sha1
@@ -1143,7 +1131,7 @@ Texts:
       - !<Location>
         Identifier: ad77e09:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 546, Col 20 @ Ln 549, Col 14
+        Ranges: Ln 541, Col 20 @ Ln 544, Col 14
   - !<Text>
     Identifier: 9670dfb
     Algorithm: sha1
@@ -1155,7 +1143,7 @@ Texts:
       - !<Location>
         Identifier: 9670dfb:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 481, Col 21 @ Ln 481, Col 76
+        Ranges: Ln 476, Col 21 @ Ln 476, Col 76
   - !<Text>
     Identifier: 0d592d3
     Algorithm: sha1
@@ -1169,7 +1157,7 @@ Texts:
       - !<Location>
         Identifier: 0d592d3:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 811, Col 21 @ Ln 814, Col 22
+        Ranges: Ln 806, Col 21 @ Ln 809, Col 22
   - !<Text>
     Identifier: e2d8fab
     Algorithm: sha1
@@ -1195,7 +1183,7 @@ Texts:
       - !<Location>
         Identifier: 378fb16:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 239, Col 13 @ Ln 239, Col 47
+        Ranges: Ln 246, Col 13 @ Ln 246, Col 47
   - !<Text>
     Identifier: a2acebe
     Algorithm: sha1
@@ -1209,7 +1197,7 @@ Texts:
       - !<Location>
         Identifier: a2acebe:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 567, Col 21 @ Ln 570, Col 22
+        Ranges: Ln 562, Col 21 @ Ln 565, Col 22
   - !<Text>
     Identifier: da9cc89
     Algorithm: sha1
@@ -1271,7 +1259,7 @@ Texts:
       - !<Location>
         Identifier: b267cef:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 466, Col 25 @ Ln 473, Col 26
+        Ranges: Ln 461, Col 25 @ Ln 468, Col 26
   - !<Text>
     Identifier: 8cbc334
     Algorithm: sha1
@@ -1283,7 +1271,7 @@ Texts:
       - !<Location>
         Identifier: 8cbc334:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 647, Col 21 @ Ln 647, Col 85
+        Ranges: Ln 642, Col 21 @ Ln 642, Col 85
   - !<Text>
     Identifier: ea57967
     Algorithm: sha1
@@ -1312,18 +1300,6 @@ Texts:
         Identifier: b66eca7:l1
         Path: ./R/ui-panel-descriptive-statistics.R
         Ranges: Ln 259, Col 13 @ Ln 264, Col 14
-  - !<Text>
-    Identifier: 59f9427
-    Algorithm: sha1
-    Hash: 59f94273bde5eaa2d43ef32eee175d2d0cb7afc7
-    Source Language: en
-    Source Text: Submit a bug or provide feedback to the maintainers.
-    Translations: ~
-    Locations:
-      - !<Location>
-        Identifier: 59f9427:l1
-        Path: ./R/ui-title.R
-        Ranges: Ln 367, Col 54 @ Ln 369, Col 14
   - !<Text>
     Identifier: 23eb033
     Algorithm: sha1
@@ -1381,21 +1357,7 @@ Texts:
       - !<Location>
         Identifier: 5f12363:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 436, Col 21 @ Ln 436, Col 83
-  - !<Text>
-    Identifier: 9895a88
-    Algorithm: sha1
-    Hash: 9895a88d97c848109e620a576313f12b68166ae7
-    Source Language: en
-    Source Text: |-
-      Get more information on this application and learn how to use it
-      properly.
-    Translations: ~
-    Locations:
-      - !<Location>
-        Identifier: 9895a88:l1
-        Path: ./R/ui-modal-faq.R
-        Ranges: Ln 294, Col 54 @ Ln 297, Col 14
+        Ranges: Ln 431, Col 21 @ Ln 431, Col 83
   - !<Text>
     Identifier: 21d66f8
     Algorithm: sha1
@@ -1465,7 +1427,7 @@ Texts:
       - !<Location>
         Identifier: 5518029:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 505, Col 21 @ Ln 507, Col 14
+        Ranges: Ln 500, Col 21 @ Ln 502, Col 14
   - !<Text>
     Identifier: 501a2ee
     Algorithm: sha1
@@ -1478,18 +1440,6 @@ Texts:
         Identifier: 501a2ee:l1
         Path: ./R/ui-panel-descriptive-statistics.R
         Ranges: Ln 276, Col 39 @ Ln 276, Col 78
-  - !<Text>
-    Identifier: e6a9040
-    Algorithm: sha1
-    Hash: e6a904003b5c792e5efbb07c5ed935c1cc89f275
-    Source Language: en
-    Source Text: Choose your preferred language.
-    Translations: ~
-    Locations:
-      - !<Location>
-        Identifier: e6a9040:l1
-        Path: ./R/ui-title.R
-        Ranges: Ln 354, Col 56 @ Ln 356, Col 14
   - !<Text>
     Identifier: 4dd1267
     Algorithm: sha1
@@ -1521,7 +1471,7 @@ Texts:
       - !<Location>
         Identifier: 3710c88:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 845, Col 29 @ Ln 851, Col 30
+        Ranges: Ln 840, Col 29 @ Ln 846, Col 30
   - !<Text>
     Identifier: a5a2911
     Algorithm: sha1
@@ -1586,7 +1536,7 @@ Texts:
       - !<Location>
         Identifier: 20a872f:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 390, Col 21 @ Ln 394, Col 22
+        Ranges: Ln 385, Col 21 @ Ln 389, Col 22
   - !<Text>
     Identifier: 0e99366
     Algorithm: sha1
@@ -1625,7 +1575,7 @@ Texts:
       - !<Location>
         Identifier: a7c73b7:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 440, Col 21 @ Ln 444, Col 22
+        Ranges: Ln 435, Col 21 @ Ln 439, Col 22
   - !<Text>
     Identifier: 2bbf9dd
     Algorithm: sha1
@@ -1637,7 +1587,7 @@ Texts:
       - !<Location>
         Identifier: 2bbf9dd:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 384, Col 21 @ Ln 386, Col 14
+        Ranges: Ln 379, Col 21 @ Ln 381, Col 14
   - !<Text>
     Identifier: 7d94d60
     Algorithm: sha1
@@ -1680,6 +1630,18 @@ Texts:
         Path: ./R/ui-panel-descriptive-statistics.R
         Ranges: Ln 233, Col 21 @ Ln 233, Col 51
   - !<Text>
+    Identifier: cb9ddbb
+    Algorithm: sha1
+    Hash: cb9ddbb485c1f06a511342b9f69216412863e2f8
+    Source Language: en
+    Source Text: Submit a bug or provide feedback to the maintainers by email.
+    Translations: ~
+    Locations:
+      - !<Location>
+        Identifier: cb9ddbb:l1
+        Path: ./R/ui-title.R
+        Ranges: Ln 390, Col 54 @ Ln 392, Col 14
+  - !<Text>
     Identifier: 0595dc0
     Algorithm: sha1
     Hash: 0595dc09f0922030fa5758085cdb454bbaa97055
@@ -1708,7 +1670,7 @@ Texts:
       - !<Location>
         Identifier: ff8d5e3:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 331, Col 20 @ Ln 340, Col 14
+        Ranges: Ln 326, Col 20 @ Ln 335, Col 14
   - !<Text>
     Identifier: 9eef958
     Algorithm: sha1
@@ -1723,7 +1685,7 @@ Texts:
       - !<Location>
         Identifier: 9eef958:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 619, Col 25 @ Ln 624, Col 26
+        Ranges: Ln 614, Col 25 @ Ln 619, Col 26
   - !<Text>
     Identifier: 5dc95f8
     Algorithm: sha1
@@ -1735,7 +1697,7 @@ Texts:
       - !<Location>
         Identifier: 5dc95f8:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 249, Col 13 @ Ln 249, Col 45
+        Ranges: Ln 256, Col 13 @ Ln 256, Col 45
   - !<Text>
     Identifier: c2bb46d
     Algorithm: sha1
@@ -1747,7 +1709,7 @@ Texts:
       - !<Location>
         Identifier: c2bb46d:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 803, Col 21 @ Ln 805, Col 22
+        Ranges: Ln 798, Col 21 @ Ln 800, Col 22
   - !<Text>
     Identifier: 930bac6
     Algorithm: sha1
@@ -1759,7 +1721,7 @@ Texts:
       - !<Location>
         Identifier: 930bac6:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 659, Col 21 @ Ln 659, Col 73
+        Ranges: Ln 654, Col 21 @ Ln 654, Col 73
   - !<Text>
     Identifier: 1b5e945
     Algorithm: sha1
@@ -1771,7 +1733,7 @@ Texts:
       - !<Location>
         Identifier: 1b5e945:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 576, Col 21 @ Ln 579, Col 22
+        Ranges: Ln 571, Col 21 @ Ln 574, Col 22
   - !<Text>
     Identifier: ad9a641
     Algorithm: sha1
@@ -1783,7 +1745,7 @@ Texts:
       - !<Location>
         Identifier: ad9a641:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 346, Col 21 @ Ln 346, Col 65
+        Ranges: Ln 341, Col 21 @ Ln 341, Col 65
   - !<Text>
     Identifier: 02a9a58
     Algorithm: sha1
@@ -1889,7 +1851,7 @@ Texts:
       - !<Location>
         Identifier: 5e2c2fa:l1
         Path: ./R/ui-title.R
-        Ranges: Ln 299, Col 21 @ Ln 299, Col 52
+        Ranges: Ln 330, Col 21 @ Ln 330, Col 52
   - !<Text>
     Identifier: fd52582
     Algorithm: sha1
@@ -1932,7 +1894,7 @@ Texts:
       - !<Location>
         Identifier: 4f7aff7:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 587, Col 21 @ Ln 587, Col 84
+        Ranges: Ln 582, Col 21 @ Ln 582, Col 84
   - !<Text>
     Identifier: b740be6
     Algorithm: sha1
@@ -1944,7 +1906,7 @@ Texts:
       - !<Location>
         Identifier: b740be6:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 487, Col 21 @ Ln 487, Col 83
+        Ranges: Ln 482, Col 21 @ Ln 482, Col 83
   - !<Text>
     Identifier: 5bbca33
     Algorithm: sha1
@@ -2055,7 +2017,7 @@ Texts:
       - !<Location>
         Identifier: 8141885:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 511, Col 21 @ Ln 516, Col 22
+        Ranges: Ln 506, Col 21 @ Ln 511, Col 22
   - !<Text>
     Identifier: 1a51cee
     Algorithm: sha1
@@ -2067,7 +2029,7 @@ Texts:
       - !<Location>
         Identifier: 1a51cee:l1
         Path: ./R/ui-title.R
-        Ranges: Ln 303, Col 21 @ Ln 303, Col 52
+        Ranges: Ln 334, Col 21 @ Ln 334, Col 52
   - !<Text>
     Identifier: 899d691
     Algorithm: sha1
@@ -2081,7 +2043,7 @@ Texts:
       - !<Location>
         Identifier: 899d691:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 671, Col 21 @ Ln 674, Col 22
+        Ranges: Ln 666, Col 21 @ Ln 669, Col 22
   - !<Text>
     Identifier: f0d17dd
     Algorithm: sha1
@@ -2110,7 +2072,7 @@ Texts:
       - !<Location>
         Identifier: 8fc2a6a:l1
         Path: ./R/ui-title.R
-        Ranges: Ln 284, Col 13 @ Ln 286, Col 14
+        Ranges: Ln 310, Col 13 @ Ln 312, Col 14
   - !<Text>
     Identifier: fffde19
     Algorithm: sha1
@@ -2127,6 +2089,18 @@ Texts:
         Path: ./R/ui-sidebar.R
         Ranges: Ln 330, Col 61 @ Ln 334, Col 14
   - !<Text>
+    Identifier: 70d45be
+    Algorithm: sha1
+    Hash: 70d45be1f58f1b57c6a634c4653bae8452c5d49e
+    Source Language: en
+    Source Text: Language
+    Translations: ~
+    Locations:
+      - !<Location>
+        Identifier: 70d45be:l1
+        Path: ./R/ui-title.R
+        Ranges: Ln 317, Col 13 @ Ln 317, Col 48
+  - !<Text>
     Identifier: 0cdc87d
     Algorithm: sha1
     Hash: 0cdc87dea7d6c6952e0e302182099be863e14952
@@ -2141,7 +2115,7 @@ Texts:
       - !<Location>
         Identifier: 0cdc87d:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 368, Col 21 @ Ln 374, Col 22
+        Ranges: Ln 363, Col 21 @ Ln 369, Col 22
   - !<Text>
     Identifier: 6db5beb
     Algorithm: sha1
@@ -2223,20 +2197,6 @@ Texts:
         Path: ./R/ui-sidebar.R
         Ranges: Ln 232, Col 13 @ Ln 236, Col 14
   - !<Text>
-    Identifier: 0705c1d
-    Algorithm: sha1
-    Hash: 0705c1dee7907a03059782e607d82defa2cb230e
-    Source Language: en
-    Source Text: |-
-      Choose your preferred color scheme. This is an experimental feature.
-      Contents may not be displayed appropriately.
-    Translations: ~
-    Locations:
-      - !<Location>
-        Identifier: 0705c1d:l1
-        Path: ./R/ui-title.R
-        Ranges: Ln 362, Col 61 @ Ln 365, Col 14
-  - !<Text>
     Identifier: b7b4f0b
     Algorithm: sha1
     Hash: b7b4f0bd5f3d0cd911e84c45210a118c51fb8073
@@ -2266,7 +2226,7 @@ Texts:
       - !<Location>
         Identifier: 9cc07de:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 401, Col 21 @ Ln 408, Col 22
+        Ranges: Ln 396, Col 21 @ Ln 403, Col 22
   - !<Text>
     Identifier: 3116c76
     Algorithm: sha1
@@ -2278,7 +2238,7 @@ Texts:
       - !<Location>
         Identifier: 3116c76:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 756, Col 37 @ Ln 756, Col 68
+        Ranges: Ln 751, Col 37 @ Ln 751, Col 68
   - !<Text>
     Identifier: 449ff93
     Algorithm: sha1
@@ -2355,7 +2315,7 @@ Texts:
       - !<Location>
         Identifier: 89fba6b:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 234, Col 13 @ Ln 234, Col 66
+        Ranges: Ln 241, Col 13 @ Ln 241, Col 66
   - !<Text>
     Identifier: ceefbab
     Algorithm: sha1
@@ -2377,6 +2337,18 @@ Texts:
         Path: ./R/ui-panel-percentiles.R
         Ranges: Ln 587, Col 38 @ Ln 587, Col 70
   - !<Text>
+    Identifier: 5d328be
+    Algorithm: sha1
+    Hash: 5d328be196b9ca21d4241565c16d3de790136974
+    Source Language: en
+    Source Text: See the source code of Tool 1 on GitHub.
+    Translations: ~
+    Locations:
+      - !<Location>
+        Identifier: 5d328be:l1
+        Path: ./R/ui-title.R
+        Ranges: Ln 386, Col 55 @ Ln 388, Col 14
+  - !<Text>
     Identifier: 9797b53
     Algorithm: sha1
     Hash: 9797b53374920aa94a856e2cb860440171f90820
@@ -2391,7 +2363,7 @@ Texts:
       - !<Location>
         Identifier: 9797b53:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 259, Col 13 @ Ln 265, Col 14
+        Ranges: Ln 266, Col 13 @ Ln 272, Col 14
   - !<Text>
     Identifier: cb21ace
     Algorithm: sha1
@@ -2403,7 +2375,19 @@ Texts:
       - !<Location>
         Identifier: cb21ace:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 589, Col 20 @ Ln 592, Col 14
+        Ranges: Ln 584, Col 20 @ Ln 587, Col 14
+  - !<Text>
+    Identifier: '7464899'
+    Algorithm: sha1
+    Hash: 74648993367e2041b592cfdd4da2c8948df0e597
+    Source Language: en
+    Source Text: FAQ
+    Translations: ~
+    Locations:
+      - !<Location>
+        Identifier: 7464899:l1
+        Path: ./R/ui-modal-faq.R
+        Ranges: Ln 236, Col 13 @ Ln 236, Col 43
   - !<Text>
     Identifier: 8a17368
     Algorithm: sha1
@@ -2415,7 +2399,7 @@ Texts:
       - !<Location>
         Identifier: 8a17368:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 698, Col 25 @ Ln 700, Col 26
+        Ranges: Ln 693, Col 25 @ Ln 695, Col 26
   - !<Text>
     Identifier: a632e97
     Algorithm: sha1
@@ -2509,7 +2493,7 @@ Texts:
       - !<Location>
         Identifier: 380f931:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 702, Col 41 @ Ln 702, Col 72
+        Ranges: Ln 697, Col 41 @ Ln 697, Col 72
       - !<Location>
         Identifier: 380f931:l2
         Path: ./R/ui-sidebar.R
@@ -2527,7 +2511,7 @@ Texts:
       - !<Location>
         Identifier: 4aabcde:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 681, Col 25 @ Ln 685, Col 26
+        Ranges: Ln 676, Col 25 @ Ln 680, Col 26
   - !<Text>
     Identifier: 9bdd102
     Algorithm: sha1
@@ -2554,7 +2538,7 @@ Texts:
       - !<Location>
         Identifier: 4c9bab6:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 324, Col 20 @ Ln 329, Col 14
+        Ranges: Ln 319, Col 20 @ Ln 324, Col 14
   - !<Text>
     Identifier: 8c8796c
     Algorithm: sha1
@@ -2566,7 +2550,7 @@ Texts:
       - !<Location>
         Identifier: 8c8796c:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 746, Col 21 @ Ln 746, Col 68
+        Ranges: Ln 741, Col 21 @ Ln 741, Col 68
   - !<Text>
     Identifier: '9616619'
     Algorithm: sha1
@@ -2581,7 +2565,7 @@ Texts:
       - !<Location>
         Identifier: 9616619:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 493, Col 21 @ Ln 497, Col 22
+        Ranges: Ln 488, Col 21 @ Ln 492, Col 22
   - !<Text>
     Identifier: 865ddc6
     Algorithm: sha1
@@ -2623,7 +2607,7 @@ Texts:
       - !<Location>
         Identifier: 1a0644e:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 609, Col 21 @ Ln 612, Col 22
+        Ranges: Ln 604, Col 21 @ Ln 607, Col 22
   - !<Text>
     Identifier: aeaec6e
     Algorithm: sha1
@@ -2637,7 +2621,7 @@ Texts:
       - !<Location>
         Identifier: aeaec6e:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 711, Col 21 @ Ln 714, Col 22
+        Ranges: Ln 706, Col 21 @ Ln 709, Col 22
   - !<Text>
     Identifier: 3eba509
     Algorithm: sha1
@@ -2721,7 +2705,7 @@ Texts:
       - !<Location>
         Identifier: 54697e1:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 661, Col 20 @ Ln 663, Col 14
+        Ranges: Ln 656, Col 20 @ Ln 658, Col 14
   - !<Text>
     Identifier: 4e85c1b
     Algorithm: sha1
@@ -2735,7 +2719,7 @@ Texts:
       - !<Location>
         Identifier: 4e85c1b:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 649, Col 20 @ Ln 653, Col 14
+        Ranges: Ln 644, Col 20 @ Ln 648, Col 14
   - !<Text>
     Identifier: 38210f7
     Algorithm: sha1
@@ -2749,7 +2733,7 @@ Texts:
       - !<Location>
         Identifier: 38210f7:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 558, Col 21 @ Ln 561, Col 22
+        Ranges: Ln 553, Col 21 @ Ln 556, Col 22
   - !<Text>
     Identifier: 6bf9771
     Algorithm: sha1
@@ -2761,7 +2745,7 @@ Texts:
       - !<Location>
         Identifier: 6bf9771:l1
         Path: ./R/ui-title.R
-        Ranges: Ln 295, Col 21 @ Ln 295, Col 65
+        Ranges: Ln 326, Col 21 @ Ln 326, Col 65
   - !<Text>
     Identifier: da34e30
     Algorithm: sha1

--- a/intl/_translator.yml
+++ b/intl/_translator.yml
@@ -58,15 +58,15 @@ Texts:
       - !<Location>
         Identifier: 4e2a12c:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 395, Col 25 @ Ln 398, Col 26
+        Ranges: Ln 391, Col 25 @ Ln 394, Col 26
       - !<Location>
         Identifier: 4e2a12c:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 398, Col 25 @ Ln 401, Col 26
+        Ranges: Ln 394, Col 25 @ Ln 397, Col 26
       - !<Location>
         Identifier: 4e2a12c:l3
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 383, Col 25 @ Ln 386, Col 26
+        Ranges: Ln 379, Col 25 @ Ln 382, Col 26
   - !<Text>
     Identifier: '2348472'
     Algorithm: sha1
@@ -97,7 +97,7 @@ Texts:
       - !<Location>
         Identifier: ef12e2b:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 645, Col 17 @ Ln 657, Col 18
+        Ranges: Ln 641, Col 17 @ Ln 653, Col 18
   - !<Text>
     Identifier: 7e9d895
     Algorithm: sha1
@@ -109,15 +109,15 @@ Texts:
       - !<Location>
         Identifier: 7e9d895:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 302, Col 37 @ Ln 302, Col 81
+        Ranges: Ln 298, Col 37 @ Ln 298, Col 81
       - !<Location>
         Identifier: 7e9d895:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 298, Col 37 @ Ln 298, Col 81
+        Ranges: Ln 294, Col 37 @ Ln 294, Col 81
       - !<Location>
         Identifier: 7e9d895:l3
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 283, Col 37 @ Ln 283, Col 81
+        Ranges: Ln 279, Col 37 @ Ln 279, Col 81
   - !<Text>
     Identifier: f6e929e
     Algorithm: sha1
@@ -182,15 +182,15 @@ Texts:
       - !<Location>
         Identifier: e80025a:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 353, Col 13 @ Ln 353, Col 55
+        Ranges: Ln 349, Col 13 @ Ln 349, Col 55
       - !<Location>
         Identifier: e80025a:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 349, Col 13 @ Ln 349, Col 55
+        Ranges: Ln 345, Col 13 @ Ln 345, Col 55
       - !<Location>
         Identifier: e80025a:l3
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 334, Col 13 @ Ln 334, Col 55
+        Ranges: Ln 330, Col 13 @ Ln 330, Col 55
   - !<Text>
     Identifier: 3d4f8d5
     Algorithm: sha1
@@ -215,8 +215,8 @@ Texts:
         Identifier: 1de8474:l1
         Path: ./R/ui-panel-arithmetic-mean.R
         Ranges:
-          - Ln 577, Col 29 @ Ln 577, Col 67
-          - Ln 605, Col 30 @ Ln 605, Col 68
+          - Ln 573, Col 29 @ Ln 573, Col 67
+          - Ln 601, Col 30 @ Ln 601, Col 68
       - !<Location>
         Identifier: 1de8474:l2
         Path: ./R/ui-panel-descriptive-statistics.R
@@ -225,14 +225,14 @@ Texts:
         Identifier: 1de8474:l3
         Path: ./R/ui-panel-exceedance-fraction.R
         Ranges:
-          - Ln 564, Col 29 @ Ln 564, Col 67
-          - Ln 590, Col 30 @ Ln 590, Col 68
+          - Ln 560, Col 29 @ Ln 560, Col 67
+          - Ln 586, Col 30 @ Ln 586, Col 68
       - !<Location>
         Identifier: 1de8474:l4
         Path: ./R/ui-panel-percentiles.R
         Ranges:
-          - Ln 556, Col 38 @ Ln 556, Col 76
-          - Ln 586, Col 38 @ Ln 586, Col 76
+          - Ln 552, Col 38 @ Ln 552, Col 76
+          - Ln 582, Col 38 @ Ln 582, Col 76
   - !<Text>
     Identifier: 745ebd1
     Algorithm: sha1
@@ -276,7 +276,7 @@ Texts:
       - !<Location>
         Identifier: e3d5355:l1
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 304, Col 13 @ Ln 304, Col 51
+        Ranges: Ln 300, Col 13 @ Ln 300, Col 51
   - !<Text>
     Identifier: 62fc968
     Algorithm: sha1
@@ -295,9 +295,9 @@ Texts:
         Identifier: 62fc968:l2
         Path: ./R/ui-panel-percentiles.R
         Ranges:
-          - Ln 329, Col 13 @ Ln 329, Col 50
-          - Ln 558, Col 38 @ Ln 558, Col 73
-          - Ln 590, Col 38 @ Ln 590, Col 73
+          - Ln 325, Col 13 @ Ln 325, Col 50
+          - Ln 554, Col 38 @ Ln 554, Col 73
+          - Ln 586, Col 38 @ Ln 586, Col 73
   - !<Text>
     Identifier: 5b8a460
     Algorithm: sha1
@@ -310,15 +310,15 @@ Texts:
       - !<Location>
         Identifier: 5b8a460:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 495, Col 25 @ Ln 498, Col 26
+        Ranges: Ln 491, Col 25 @ Ln 494, Col 26
       - !<Location>
         Identifier: 5b8a460:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 482, Col 25 @ Ln 485, Col 26
+        Ranges: Ln 478, Col 25 @ Ln 481, Col 26
       - !<Location>
         Identifier: 5b8a460:l3
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 467, Col 25 @ Ln 470, Col 26
+        Ranges: Ln 463, Col 25 @ Ln 466, Col 26
   - !<Text>
     Identifier: 463c845
     Algorithm: sha1
@@ -333,7 +333,7 @@ Texts:
       - !<Location>
         Identifier: 463c845:l1
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 599, Col 13 @ Ln 604, Col 14
+        Ranges: Ln 595, Col 13 @ Ln 600, Col 14
   - !<Text>
     Identifier: f7a0860
     Algorithm: sha1
@@ -365,11 +365,11 @@ Texts:
       - !<Location>
         Identifier: 5f52075:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 636, Col 31 @ Ln 636, Col 71
+        Ranges: Ln 632, Col 31 @ Ln 632, Col 71
       - !<Location>
         Identifier: 5f52075:l2
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 622, Col 31 @ Ln 622, Col 71
+        Ranges: Ln 618, Col 31 @ Ln 618, Col 71
   - !<Text>
     Identifier: fc5b077
     Algorithm: sha1
@@ -381,15 +381,15 @@ Texts:
       - !<Location>
         Identifier: fc5b077:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 607, Col 30 @ Ln 607, Col 87
+        Ranges: Ln 603, Col 30 @ Ln 603, Col 87
       - !<Location>
         Identifier: fc5b077:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 593, Col 30 @ Ln 593, Col 87
+        Ranges: Ln 589, Col 30 @ Ln 589, Col 87
       - !<Location>
         Identifier: fc5b077:l3
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 588, Col 38 @ Ln 588, Col 95
+        Ranges: Ln 584, Col 38 @ Ln 584, Col 95
   - !<Text>
     Identifier: 2970e5a
     Algorithm: sha1
@@ -414,15 +414,15 @@ Texts:
       - !<Location>
         Identifier: 59715a2:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 532, Col 25 @ Ln 535, Col 26
+        Ranges: Ln 528, Col 25 @ Ln 531, Col 26
       - !<Location>
         Identifier: 59715a2:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 519, Col 25 @ Ln 522, Col 26
+        Ranges: Ln 515, Col 25 @ Ln 518, Col 26
       - !<Location>
         Identifier: 59715a2:l3
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 508, Col 25 @ Ln 511, Col 26
+        Ranges: Ln 504, Col 25 @ Ln 507, Col 26
   - !<Text>
     Identifier: 2052e8c
     Algorithm: sha1
@@ -461,7 +461,7 @@ Texts:
       - !<Location>
         Identifier: 7be717b:l1
         Path: ./R/ui-footer.R
-        Ranges: Ln 70, Col 21 @ Ln 70, Col 67
+        Ranges: Ln 73, Col 21 @ Ln 73, Col 67
   - !<Text>
     Identifier: 92193c3
     Algorithm: sha1
@@ -514,10 +514,10 @@ Texts:
         Identifier: df83adb:l1
         Path: ./R/ui-panel-arithmetic-mean.R
         Ranges:
-          - Ln 323, Col 13 @ Ln 323, Col 55
-          - Ln 348, Col 13 @ Ln 348, Col 55
-          - Ln 579, Col 29 @ Ln 579, Col 69
-          - Ln 609, Col 30 @ Ln 609, Col 70
+          - Ln 319, Col 13 @ Ln 319, Col 55
+          - Ln 344, Col 13 @ Ln 344, Col 55
+          - Ln 575, Col 29 @ Ln 575, Col 69
+          - Ln 605, Col 30 @ Ln 605, Col 70
       - !<Location>
         Identifier: df83adb:l2
         Path: ./R/ui-panel-descriptive-statistics.R
@@ -569,7 +569,7 @@ Texts:
       - !<Location>
         Identifier: a32a1f9:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 585, Col 13 @ Ln 592, Col 14
+        Ranges: Ln 581, Col 13 @ Ln 588, Col 14
   - !<Text>
     Identifier: 1dba349
     Algorithm: sha1
@@ -584,15 +584,15 @@ Texts:
       - !<Location>
         Identifier: 1dba349:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 464, Col 13 @ Ln 468, Col 14
+        Ranges: Ln 460, Col 13 @ Ln 464, Col 14
       - !<Location>
         Identifier: 1dba349:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 451, Col 13 @ Ln 455, Col 14
+        Ranges: Ln 447, Col 13 @ Ln 451, Col 14
       - !<Location>
         Identifier: 1dba349:l3
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 436, Col 13 @ Ln 440, Col 14
+        Ranges: Ln 432, Col 13 @ Ln 436, Col 14
   - !<Text>
     Identifier: db16b44
     Algorithm: sha1
@@ -634,7 +634,7 @@ Texts:
       - !<Location>
         Identifier: 6298302:l1
         Path: ./R/ui-sidebar.R
-        Ranges: Ln 348, Col 57 @ Ln 350, Col 14
+        Ranges: Ln 349, Col 57 @ Ln 351, Col 14
   - !<Text>
     Identifier: 8d5cf97
     Algorithm: sha1
@@ -648,6 +648,22 @@ Texts:
         Path: ./R/ui-exceedance-plot.R
         Ranges: Ln 370, Col 27 @ Ln 370, Col 60
   - !<Text>
+    Identifier: 68c086f
+    Algorithm: sha1
+    Hash: 68c086f367deb32174a2aa64fba2cf4df0153b6c
+    Source Language: en
+    Source Text: |-
+      The measurement dataset. There must be one value per line. Values can be
+      censored to the left (<), to the right (>), or interval censored ([X-Y]).
+      For more information, see the Calculation Parameters section in
+      Frequently Asked Questions (FAQ) above.
+    Translations: ~
+    Locations:
+      - !<Location>
+        Identifier: 68c086f:l1
+        Path: ./R/ui-sidebar.R
+        Ranges: Ln 342, Col 51 @ Ln 347, Col 14
+  - !<Text>
     Identifier: d257a4e
     Algorithm: sha1
     Hash: d257a4e6645f4dc5240b86db354f00a9dde4d62d
@@ -658,11 +674,11 @@ Texts:
       - !<Location>
         Identifier: d257a4e:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 634, Col 31 @ Ln 634, Col 64
+        Ranges: Ln 630, Col 31 @ Ln 630, Col 64
       - !<Location>
         Identifier: d257a4e:l2
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 620, Col 31 @ Ln 620, Col 64
+        Ranges: Ln 616, Col 31 @ Ln 616, Col 64
   - !<Text>
     Identifier: 80d1a60
     Algorithm: sha1
@@ -674,7 +690,7 @@ Texts:
       - !<Location>
         Identifier: 80d1a60:l1
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 619, Col 34 @ Ln 619, Col 87
+        Ranges: Ln 615, Col 34 @ Ln 615, Col 87
   - !<Text>
     Identifier: 962996f
     Algorithm: sha1
@@ -740,15 +756,15 @@ Texts:
       - !<Location>
         Identifier: 9add3cf:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 333, Col 13 @ Ln 333, Col 50
+        Ranges: Ln 329, Col 13 @ Ln 329, Col 50
       - !<Location>
         Identifier: 9add3cf:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 329, Col 13 @ Ln 329, Col 50
+        Ranges: Ln 325, Col 13 @ Ln 325, Col 50
       - !<Location>
         Identifier: 9add3cf:l3
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 314, Col 13 @ Ln 314, Col 50
+        Ranges: Ln 310, Col 13 @ Ln 310, Col 50
   - !<Text>
     Identifier: 8cdd8fb
     Algorithm: sha1
@@ -800,18 +816,18 @@ Texts:
         Identifier: ad1e98e:l1
         Path: ./R/ui-panel-arithmetic-mean.R
         Ranges:
-          - Ln 578, Col 29 @ Ln 578, Col 57
-          - Ln 608, Col 30 @ Ln 608, Col 58
+          - Ln 574, Col 29 @ Ln 574, Col 57
+          - Ln 604, Col 30 @ Ln 604, Col 58
       - !<Location>
         Identifier: ad1e98e:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 594, Col 30 @ Ln 594, Col 58
+        Ranges: Ln 590, Col 30 @ Ln 590, Col 58
       - !<Location>
         Identifier: ad1e98e:l3
         Path: ./R/ui-panel-percentiles.R
         Ranges:
-          - Ln 557, Col 38 @ Ln 557, Col 66
-          - Ln 589, Col 38 @ Ln 589, Col 66
+          - Ln 553, Col 38 @ Ln 553, Col 66
+          - Ln 585, Col 38 @ Ln 585, Col 66
   - !<Text>
     Identifier: b3c553f
     Algorithm: sha1
@@ -837,15 +853,15 @@ Texts:
       - !<Location>
         Identifier: cebe5c4:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 580, Col 29 @ Ln 580, Col 71
+        Ranges: Ln 576, Col 29 @ Ln 576, Col 71
       - !<Location>
         Identifier: cebe5c4:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 566, Col 29 @ Ln 566, Col 71
+        Ranges: Ln 562, Col 29 @ Ln 562, Col 71
       - !<Location>
         Identifier: cebe5c4:l3
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 559, Col 38 @ Ln 559, Col 80
+        Ranges: Ln 555, Col 38 @ Ln 555, Col 80
   - !<Text>
     Identifier: f10baab
     Algorithm: sha1
@@ -857,15 +873,15 @@ Texts:
       - !<Location>
         Identifier: f10baab:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 633, Col 31 @ Ln 633, Col 67
+        Ranges: Ln 629, Col 31 @ Ln 629, Col 67
       - !<Location>
         Identifier: f10baab:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 620, Col 34 @ Ln 620, Col 70
+        Ranges: Ln 616, Col 34 @ Ln 616, Col 70
       - !<Location>
         Identifier: f10baab:l3
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 619, Col 31 @ Ln 619, Col 67
+        Ranges: Ln 615, Col 31 @ Ln 615, Col 67
   - !<Text>
     Identifier: 6918de6
     Algorithm: sha1
@@ -906,7 +922,7 @@ Texts:
       - !<Location>
         Identifier: ac24260:l1
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 383, Col 25 @ Ln 386, Col 26
+        Ranges: Ln 379, Col 25 @ Ln 382, Col 26
   - !<Text>
     Identifier: d111f1a
     Algorithm: sha1
@@ -918,15 +934,15 @@ Texts:
       - !<Location>
         Identifier: d111f1a:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 358, Col 13 @ Ln 358, Col 52
+        Ranges: Ln 354, Col 13 @ Ln 354, Col 52
       - !<Location>
         Identifier: d111f1a:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 354, Col 13 @ Ln 354, Col 52
+        Ranges: Ln 350, Col 13 @ Ln 350, Col 52
       - !<Location>
         Identifier: d111f1a:l3
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 339, Col 13 @ Ln 339, Col 52
+        Ranges: Ln 335, Col 13 @ Ln 335, Col 52
   - !<Text>
     Identifier: f59a9a9
     Algorithm: sha1
@@ -1045,7 +1061,7 @@ Texts:
       - !<Location>
         Identifier: 1fa04de:l1
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 630, Col 17 @ Ln 640, Col 18
+        Ranges: Ln 626, Col 17 @ Ln 636, Col 18
   - !<Text>
     Identifier: af71ace
     Algorithm: sha1
@@ -1081,15 +1097,15 @@ Texts:
       - !<Location>
         Identifier: 99db36b:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 312, Col 37 @ Ln 312, Col 85
+        Ranges: Ln 308, Col 37 @ Ln 308, Col 85
       - !<Location>
         Identifier: 99db36b:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 308, Col 37 @ Ln 308, Col 85
+        Ranges: Ln 304, Col 37 @ Ln 304, Col 85
       - !<Location>
         Identifier: 99db36b:l3
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 293, Col 37 @ Ln 293, Col 85
+        Ranges: Ln 289, Col 37 @ Ln 289, Col 85
   - !<Text>
     Identifier: 9d61612
     Algorithm: sha1
@@ -1117,7 +1133,7 @@ Texts:
       - !<Location>
         Identifier: e510a31:l1
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 489, Col 25 @ Ln 492, Col 26
+        Ranges: Ln 485, Col 25 @ Ln 488, Col 26
   - !<Text>
     Identifier: ad77e09
     Algorithm: sha1
@@ -1209,15 +1225,15 @@ Texts:
       - !<Location>
         Identifier: da9cc89:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 363, Col 13 @ Ln 363, Col 54
+        Ranges: Ln 359, Col 13 @ Ln 359, Col 54
       - !<Location>
         Identifier: da9cc89:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 359, Col 13 @ Ln 359, Col 54
+        Ranges: Ln 355, Col 13 @ Ln 355, Col 54
       - !<Location>
         Identifier: da9cc89:l3
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 344, Col 13 @ Ln 344, Col 54
+        Ranges: Ln 340, Col 13 @ Ln 340, Col 54
   - !<Text>
     Identifier: da5e3d2
     Algorithm: sha1
@@ -1231,7 +1247,7 @@ Texts:
       - !<Location>
         Identifier: da5e3d2:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 386, Col 21 @ Ln 389, Col 22
+        Ranges: Ln 382, Col 21 @ Ln 385, Col 22
   - !<Text>
     Identifier: 10ef3a6
     Algorithm: sha1
@@ -1311,7 +1327,7 @@ Texts:
       - !<Location>
         Identifier: 23eb033:l1
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 625, Col 31 @ Ln 625, Col 84
+        Ranges: Ln 621, Col 31 @ Ln 621, Col 84
   - !<Text>
     Identifier: 1d671e4
     Algorithm: sha1
@@ -1325,7 +1341,7 @@ Texts:
       - !<Location>
         Identifier: 1d671e4:l1
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 368, Col 25 @ Ln 371, Col 26
+        Ranges: Ln 364, Col 25 @ Ln 367, Col 26
   - !<Text>
     Identifier: be6fb8b
     Algorithm: sha1
@@ -1393,15 +1409,15 @@ Texts:
       - !<Location>
         Identifier: e0147d1:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 480, Col 25 @ Ln 483, Col 26
+        Ranges: Ln 476, Col 25 @ Ln 479, Col 26
       - !<Location>
         Identifier: e0147d1:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 467, Col 25 @ Ln 470, Col 26
+        Ranges: Ln 463, Col 25 @ Ln 466, Col 26
       - !<Location>
         Identifier: e0147d1:l3
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 452, Col 25 @ Ln 455, Col 26
+        Ranges: Ln 448, Col 25 @ Ln 451, Col 26
   - !<Text>
     Identifier: 897e74a
     Algorithm: sha1
@@ -1484,10 +1500,10 @@ Texts:
         Identifier: a5a2911:l1
         Path: ./R/ui-panel-exceedance-fraction.R
         Ranges:
-          - Ln 319, Col 13 @ Ln 319, Col 59
-          - Ln 344, Col 13 @ Ln 344, Col 59
-          - Ln 565, Col 29 @ Ln 565, Col 73
-          - Ln 592, Col 30 @ Ln 592, Col 74
+          - Ln 315, Col 13 @ Ln 315, Col 59
+          - Ln 340, Col 13 @ Ln 340, Col 59
+          - Ln 561, Col 29 @ Ln 561, Col 73
+          - Ln 588, Col 30 @ Ln 588, Col 74
   - !<Text>
     Identifier: 4528da3
     Algorithm: sha1
@@ -1548,7 +1564,7 @@ Texts:
       - !<Location>
         Identifier: 0e99366:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 639, Col 31 @ Ln 639, Col 80
+        Ranges: Ln 635, Col 31 @ Ln 635, Col 80
   - !<Text>
     Identifier: 24a1b71
     Algorithm: sha1
@@ -1604,7 +1620,7 @@ Texts:
       - !<Location>
         Identifier: 7d94d60:l1
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 595, Col 13 @ Ln 602, Col 14
+        Ranges: Ln 591, Col 13 @ Ln 598, Col 14
   - !<Text>
     Identifier: 1ad7b08
     Algorithm: sha1
@@ -1652,7 +1668,7 @@ Texts:
       - !<Location>
         Identifier: 0595dc0:l1
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 504, Col 25 @ Ln 507, Col 26
+        Ranges: Ln 500, Col 25 @ Ln 503, Col 26
   - !<Text>
     Identifier: ff8d5e3
     Algorithm: sha1
@@ -1764,7 +1780,7 @@ Texts:
       - !<Location>
         Identifier: 02a9a58:l1
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 631, Col 17 @ Ln 644, Col 18
+        Ranges: Ln 627, Col 17 @ Ln 640, Col 18
   - !<Text>
     Identifier: f69c2db
     Algorithm: sha1
@@ -1776,15 +1792,15 @@ Texts:
       - !<Location>
         Identifier: f69c2db:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 338, Col 13 @ Ln 338, Col 49
+        Ranges: Ln 334, Col 13 @ Ln 334, Col 49
       - !<Location>
         Identifier: f69c2db:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 334, Col 13 @ Ln 334, Col 49
+        Ranges: Ln 330, Col 13 @ Ln 330, Col 49
       - !<Location>
         Identifier: f69c2db:l3
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 319, Col 13 @ Ln 319, Col 49
+        Ranges: Ln 315, Col 13 @ Ln 315, Col 49
   - !<Text>
     Identifier: cf880eb
     Algorithm: sha1
@@ -1796,7 +1812,7 @@ Texts:
       - !<Location>
         Identifier: cf880eb:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 517, Col 25 @ Ln 520, Col 26
+        Ranges: Ln 513, Col 25 @ Ln 516, Col 26
   - !<Text>
     Identifier: 036cb38
     Algorithm: sha1
@@ -1811,7 +1827,7 @@ Texts:
       - !<Location>
         Identifier: 036cb38:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 614, Col 13 @ Ln 619, Col 14
+        Ranges: Ln 610, Col 13 @ Ln 615, Col 14
   - !<Text>
     Identifier: f533761
     Algorithm: sha1
@@ -1835,11 +1851,11 @@ Texts:
       - !<Location>
         Identifier: c165d34:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 635, Col 31 @ Ln 635, Col 70
+        Ranges: Ln 631, Col 31 @ Ln 631, Col 70
       - !<Location>
         Identifier: c165d34:l2
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 621, Col 31 @ Ln 621, Col 70
+        Ranges: Ln 617, Col 31 @ Ln 617, Col 70
   - !<Text>
     Identifier: 5e2c2fa
     Algorithm: sha1
@@ -1882,7 +1898,7 @@ Texts:
       - !<Location>
         Identifier: bdd75ae:l1
         Path: ./R/ui-sidebar.R
-        Ranges: Ln 352, Col 56 @ Ln 355, Col 14
+        Ranges: Ln 353, Col 56 @ Ln 356, Col 14
   - !<Text>
     Identifier: 4f7aff7
     Algorithm: sha1
@@ -1942,15 +1958,15 @@ Texts:
       - !<Location>
         Identifier: 79e5ee7:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 343, Col 13 @ Ln 343, Col 63
+        Ranges: Ln 339, Col 13 @ Ln 339, Col 63
       - !<Location>
         Identifier: 79e5ee7:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 339, Col 13 @ Ln 339, Col 63
+        Ranges: Ln 335, Col 13 @ Ln 335, Col 63
       - !<Location>
         Identifier: 79e5ee7:l3
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 324, Col 13 @ Ln 324, Col 63
+        Ranges: Ln 320, Col 13 @ Ln 320, Col 63
   - !<Text>
     Identifier: '7034018'
     Algorithm: sha1
@@ -1978,11 +1994,11 @@ Texts:
       - !<Location>
         Identifier: 27c579f:l1
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 571, Col 13 @ Ln 577, Col 14
+        Ranges: Ln 567, Col 13 @ Ln 573, Col 14
       - !<Location>
         Identifier: 27c579f:l2
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 564, Col 13 @ Ln 570, Col 14
+        Ranges: Ln 560, Col 13 @ Ln 566, Col 14
   - !<Text>
     Identifier: c73ed1b
     Algorithm: sha1
@@ -1994,15 +2010,15 @@ Texts:
       - !<Location>
         Identifier: c73ed1b:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 562, Col 13 @ Ln 564, Col 14
+        Ranges: Ln 558, Col 13 @ Ln 560, Col 14
       - !<Location>
         Identifier: c73ed1b:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 549, Col 13 @ Ln 551, Col 14
+        Ranges: Ln 545, Col 13 @ Ln 547, Col 14
       - !<Location>
         Identifier: c73ed1b:l3
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 538, Col 13 @ Ln 540, Col 14
+        Ranges: Ln 534, Col 13 @ Ln 536, Col 14
   - !<Text>
     Identifier: '8141885'
     Algorithm: sha1
@@ -2127,11 +2143,11 @@ Texts:
       - !<Location>
         Identifier: 6db5beb:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 637, Col 31 @ Ln 637, Col 72
+        Ranges: Ln 633, Col 31 @ Ln 633, Col 72
       - !<Location>
         Identifier: 6db5beb:l2
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 623, Col 31 @ Ln 623, Col 72
+        Ranges: Ln 619, Col 31 @ Ln 619, Col 72
   - !<Text>
     Identifier: 75844cd
     Algorithm: sha1
@@ -2172,15 +2188,15 @@ Texts:
       - !<Location>
         Identifier: 3be3ecd:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 547, Col 25 @ Ln 550, Col 26
+        Ranges: Ln 543, Col 25 @ Ln 546, Col 26
       - !<Location>
         Identifier: 3be3ecd:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 534, Col 25 @ Ln 537, Col 26
+        Ranges: Ln 530, Col 25 @ Ln 533, Col 26
       - !<Location>
         Identifier: 3be3ecd:l3
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 523, Col 25 @ Ln 526, Col 26
+        Ranges: Ln 519, Col 25 @ Ln 522, Col 26
   - !<Text>
     Identifier: dbb0a02
     Algorithm: sha1
@@ -2250,15 +2266,15 @@ Texts:
       - !<Location>
         Identifier: 449ff93:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 425, Col 25 @ Ln 425, Col 78
+        Ranges: Ln 421, Col 25 @ Ln 421, Col 78
       - !<Location>
         Identifier: 449ff93:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 428, Col 25 @ Ln 428, Col 78
+        Ranges: Ln 424, Col 25 @ Ln 424, Col 78
       - !<Location>
         Identifier: 449ff93:l3
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 413, Col 25 @ Ln 413, Col 78
+        Ranges: Ln 409, Col 25 @ Ln 409, Col 78
   - !<Text>
     Identifier: '9578728'
     Algorithm: sha1
@@ -2270,7 +2286,7 @@ Texts:
       - !<Location>
         Identifier: 9578728:l1
         Path: ./R/ui-footer.R
-        Ranges: Ln 63, Col 17 @ Ln 63, Col 64
+        Ranges: Ln 66, Col 17 @ Ln 66, Col 64
   - !<Text>
     Identifier: 426cfe3
     Algorithm: sha1
@@ -2291,7 +2307,7 @@ Texts:
       - !<Location>
         Identifier: 426cfe3:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 437, Col 13 @ Ln 448, Col 14
+        Ranges: Ln 433, Col 13 @ Ln 444, Col 14
   - !<Text>
     Identifier: 03c33e5
     Algorithm: sha1
@@ -2327,15 +2343,15 @@ Texts:
       - !<Location>
         Identifier: ceefbab:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 606, Col 30 @ Ln 606, Col 62
+        Ranges: Ln 602, Col 30 @ Ln 602, Col 62
       - !<Location>
         Identifier: ceefbab:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 591, Col 30 @ Ln 591, Col 62
+        Ranges: Ln 587, Col 30 @ Ln 587, Col 62
       - !<Location>
         Identifier: ceefbab:l3
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 587, Col 38 @ Ln 587, Col 70
+        Ranges: Ln 583, Col 38 @ Ln 583, Col 70
   - !<Text>
     Identifier: 5d328be
     Algorithm: sha1
@@ -2473,15 +2489,15 @@ Texts:
       - !<Location>
         Identifier: 603143d:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 410, Col 25 @ Ln 413, Col 26
+        Ranges: Ln 406, Col 25 @ Ln 409, Col 26
       - !<Location>
         Identifier: 603143d:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 413, Col 25 @ Ln 416, Col 26
+        Ranges: Ln 409, Col 25 @ Ln 412, Col 26
       - !<Location>
         Identifier: 603143d:l3
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 398, Col 25 @ Ln 401, Col 26
+        Ranges: Ln 394, Col 25 @ Ln 397, Col 26
   - !<Text>
     Identifier: 380f931
     Algorithm: sha1
@@ -2633,15 +2649,15 @@ Texts:
       - !<Location>
         Identifier: 3eba509:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 328, Col 13 @ Ln 328, Col 55
+        Ranges: Ln 324, Col 13 @ Ln 324, Col 55
       - !<Location>
         Identifier: 3eba509:l2
         Path: ./R/ui-panel-exceedance-fraction.R
-        Ranges: Ln 324, Col 13 @ Ln 324, Col 55
+        Ranges: Ln 320, Col 13 @ Ln 320, Col 55
       - !<Location>
         Identifier: 3eba509:l3
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 309, Col 13 @ Ln 309, Col 55
+        Ranges: Ln 305, Col 13 @ Ln 305, Col 55
   - !<Text>
     Identifier: '3883288'
     Algorithm: sha1
@@ -2668,20 +2684,6 @@ Texts:
         Identifier: 2502705:l1
         Path: ./R/ui-exceedance-plot.R
         Ranges: Ln 415, Col 60 @ Ln 418, Col 14
-  - !<Text>
-    Identifier: 2b83cc5
-    Algorithm: sha1
-    Hash: 2b83cc525d940618609420a991a0f687a33b2fdc
-    Source Language: en
-    Source Text: |-
-      The measurement dataset. There must be one value per line. Values can be
-      censored to the left (<), to the right (>), or interval censored ([X-Y]).
-    Translations: ~
-    Locations:
-      - !<Location>
-        Identifier: 2b83cc5:l1
-        Path: ./R/ui-sidebar.R
-        Ranges: Ln 342, Col 51 @ Ln 346, Col 14
   - !<Text>
     Identifier: 632ebd0
     Algorithm: sha1
@@ -2769,9 +2771,9 @@ Texts:
       - !<Location>
         Identifier: 532bf12:l1
         Path: ./R/ui-panel-arithmetic-mean.R
-        Ranges: Ln 638, Col 31 @ Ln 638, Col 61
+        Ranges: Ln 634, Col 31 @ Ln 634, Col 61
       - !<Location>
         Identifier: 532bf12:l2
         Path: ./R/ui-panel-percentiles.R
-        Ranges: Ln 624, Col 31 @ Ln 624, Col 61
+        Ranges: Ln 620, Col 31 @ Ln 620, Col 61
 

--- a/intl/_translator.yml
+++ b/intl/_translator.yml
@@ -34,7 +34,7 @@ Texts:
       - !<Location>
         Identifier: 1a6a68b:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 817, Col 21 @ Ln 819, Col 14
+        Ranges: Ln 836, Col 21 @ Ln 838, Col 14
   - !<Text>
     Identifier: 67c3cba
     Algorithm: sha1
@@ -46,7 +46,7 @@ Texts:
       - !<Location>
         Identifier: 67c3cba:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 773, Col 21 @ Ln 775, Col 14
+        Ranges: Ln 792, Col 21 @ Ln 794, Col 14
   - !<Text>
     Identifier: 4e2a12c
     Algorithm: sha1
@@ -131,7 +131,7 @@ Texts:
       - !<Location>
         Identifier: f6e929e:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 345, Col 21 @ Ln 349, Col 22
+        Ranges: Ln 361, Col 21 @ Ln 365, Col 22
   - !<Text>
     Identifier: 73dff8f
     Algorithm: sha1
@@ -143,7 +143,7 @@ Texts:
       - !<Location>
         Identifier: 73dff8f:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 539, Col 21 @ Ln 539, Col 75
+        Ranges: Ln 556, Col 21 @ Ln 556, Col 75
   - !<Text>
     Identifier: 6aff6b7
     Algorithm: sha1
@@ -158,7 +158,7 @@ Texts:
       - !<Location>
         Identifier: 6aff6b7:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 777, Col 20 @ Ln 781, Col 14
+        Ranges: Ln 796, Col 20 @ Ln 800, Col 14
   - !<Text>
     Identifier: 96d547d
     Algorithm: sha1
@@ -245,12 +245,12 @@ Texts:
         Identifier: 745ebd1:l1
         Path: ./R/ui-modal-faq.R
         Ranges:
-          - Ln 251, Col 13 @ Ln 251, Col 62
-          - Ln 441, Col 37 @ Ln 441, Col 84
+          - Ln 266, Col 13 @ Ln 266, Col 62
+          - Ln 458, Col 37 @ Ln 458, Col 84
       - !<Location>
         Identifier: 745ebd1:l2
         Path: ./R/ui-sidebar.R
-        Ranges: Ln 217, Col 13 @ Ln 217, Col 62
+        Ranges: Ln 222, Col 13 @ Ln 222, Col 62
   - !<Text>
     Identifier: 8f7f102
     Algorithm: sha1
@@ -345,7 +345,7 @@ Texts:
       - !<Location>
         Identifier: f7a0860:l1
         Path: ./app.R
-        Ranges: Ln 203, Col 39 @ Ln 203, Col 70
+        Ranges: Ln 208, Col 43 @ Ln 208, Col 74
       - !<Location>
         Identifier: f7a0860:l2
         Path: ./R/ui-footer.R
@@ -437,7 +437,7 @@ Texts:
       - !<Location>
         Identifier: 2052e8c:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 521, Col 21 @ Ln 526, Col 22
+        Ranges: Ln 538, Col 21 @ Ln 543, Col 22
   - !<Text>
     Identifier: '8785301'
     Algorithm: sha1
@@ -449,7 +449,7 @@ Texts:
       - !<Location>
         Identifier: 8785301:l1
         Path: ./R/ui-sidebar.R
-        Ranges: Ln 301, Col 27 @ Ln 301, Col 72
+        Ranges: Ln 306, Col 27 @ Ln 306, Col 72
   - !<Text>
     Identifier: 7be717b
     Algorithm: sha1
@@ -461,7 +461,7 @@ Texts:
       - !<Location>
         Identifier: 7be717b:l1
         Path: ./R/ui-footer.R
-        Ranges: Ln 73, Col 21 @ Ln 73, Col 67
+        Ranges: Ln 72, Col 21 @ Ln 72, Col 67
   - !<Text>
     Identifier: 92193c3
     Algorithm: sha1
@@ -473,7 +473,7 @@ Texts:
       - !<Location>
         Identifier: 92193c3:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 317, Col 21 @ Ln 317, Col 61
+        Ranges: Ln 333, Col 21 @ Ln 333, Col 61
   - !<Text>
     Identifier: 179eb27
     Algorithm: sha1
@@ -485,7 +485,7 @@ Texts:
       - !<Location>
         Identifier: 179eb27:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 454, Col 21 @ Ln 454, Col 79
+        Ranges: Ln 471, Col 21 @ Ln 471, Col 79
   - !<Text>
     Identifier: 4a8e3cf
     Algorithm: sha1
@@ -545,14 +545,14 @@ Texts:
       - !<Location>
         Identifier: dcc46c4:l1
         Path: ./app.R
-        Ranges: Ln 188, Col 9 @ Ln 188, Col 45
+        Ranges: Ln 192, Col 9 @ Ln 192, Col 45
       - !<Location>
         Identifier: dcc46c4:l2
         Path: ./R/ui-modal-faq.R
         Ranges:
-          - Ln 528, Col 38 @ Ln 528, Col 72
-          - Ln 682, Col 42 @ Ln 682, Col 76
-          - Ln 730, Col 38 @ Ln 730, Col 72
+          - Ln 545, Col 38 @ Ln 545, Col 72
+          - Ln 700, Col 42 @ Ln 700, Col 76
+          - Ln 748, Col 38 @ Ln 748, Col 72
   - !<Text>
     Identifier: a32a1f9
     Algorithm: sha1
@@ -618,7 +618,7 @@ Texts:
       - !<Location>
         Identifier: c6394ac:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 513, Col 37 @ Ln 513, Col 83
+        Ranges: Ln 530, Col 37 @ Ln 530, Col 83
       - !<Location>
         Identifier: c6394ac:l2
         Path: ./R/ui-panel-descriptive-statistics.R
@@ -634,7 +634,7 @@ Texts:
       - !<Location>
         Identifier: 6298302:l1
         Path: ./R/ui-sidebar.R
-        Ranges: Ln 349, Col 57 @ Ln 351, Col 14
+        Ranges: Ln 354, Col 57 @ Ln 356, Col 14
   - !<Text>
     Identifier: 8d5cf97
     Algorithm: sha1
@@ -662,7 +662,7 @@ Texts:
       - !<Location>
         Identifier: 68c086f:l1
         Path: ./R/ui-sidebar.R
-        Ranges: Ln 342, Col 51 @ Ln 347, Col 14
+        Ranges: Ln 347, Col 51 @ Ln 352, Col 14
   - !<Text>
     Identifier: d257a4e
     Algorithm: sha1
@@ -704,7 +704,7 @@ Texts:
       - !<Location>
         Identifier: 962996f:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 789, Col 21 @ Ln 792, Col 22
+        Ranges: Ln 808, Col 21 @ Ln 811, Col 22
   - !<Text>
     Identifier: 00b437c
     Algorithm: sha1
@@ -720,7 +720,7 @@ Texts:
       - !<Location>
         Identifier: 00b437c:l1
         Path: ./R/ui-sidebar.R
-        Ranges: Ln 314, Col 51 @ Ln 319, Col 14
+        Ranges: Ln 319, Col 51 @ Ln 324, Col 14
   - !<Text>
     Identifier: 798b335
     Algorithm: sha1
@@ -732,7 +732,7 @@ Texts:
       - !<Location>
         Identifier: 798b335:l1
         Path: ./R/ui-sidebar.R
-        Ranges: Ln 286, Col 27 @ Ln 286, Col 82
+        Ranges: Ln 291, Col 27 @ Ln 291, Col 82
   - !<Text>
     Identifier: 466a65e
     Algorithm: sha1
@@ -744,7 +744,7 @@ Texts:
       - !<Location>
         Identifier: 466a65e:l1
         Path: ./R/ui-sidebar.R
-        Ranges: Ln 291, Col 27 @ Ln 291, Col 80
+        Ranges: Ln 296, Col 27 @ Ln 296, Col 80
   - !<Text>
     Identifier: 9add3cf
     Algorithm: sha1
@@ -908,7 +908,7 @@ Texts:
       - !<Location>
         Identifier: 6489309:l1
         Path: ./R/ui-sidebar.R
-        Ranges: Ln 336, Col 58 @ Ln 340, Col 14
+        Ranges: Ln 341, Col 58 @ Ln 345, Col 14
   - !<Text>
     Identifier: ac24260
     Algorithm: sha1
@@ -956,7 +956,7 @@ Texts:
       - !<Location>
         Identifier: f59a9a9:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 745, Col 21 @ Ln 749, Col 22
+        Ranges: Ln 763, Col 21 @ Ln 767, Col 22
   - !<Text>
     Identifier: f111efa
     Algorithm: sha1
@@ -968,7 +968,7 @@ Texts:
       - !<Location>
         Identifier: f111efa:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 359, Col 21 @ Ln 359, Col 77
+        Ranges: Ln 375, Col 21 @ Ln 375, Col 77
   - !<Text>
     Identifier: 6863c44
     Algorithm: sha1
@@ -980,7 +980,7 @@ Texts:
       - !<Location>
         Identifier: 6863c44:l1
         Path: ./R/ui-sidebar.R
-        Ranges: Ln 227, Col 13 @ Ln 227, Col 45
+        Ranges: Ln 232, Col 13 @ Ln 232, Col 45
   - !<Text>
     Identifier: ecd9787
     Algorithm: sha1
@@ -1004,7 +1004,7 @@ Texts:
       - !<Location>
         Identifier: f3c096c:l1
         Path: ./R/ui-sidebar.R
-        Ranges: Ln 241, Col 13 @ Ln 244, Col 14
+        Ranges: Ln 246, Col 13 @ Ln 249, Col 14
   - !<Text>
     Identifier: fa75cdd
     Algorithm: sha1
@@ -1028,7 +1028,7 @@ Texts:
       - !<Location>
         Identifier: 9725731:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 261, Col 13 @ Ln 261, Col 65
+        Ranges: Ln 276, Col 13 @ Ln 276, Col 65
   - !<Text>
     Identifier: f08555d
     Algorithm: sha1
@@ -1044,7 +1044,7 @@ Texts:
       - !<Location>
         Identifier: f08555d:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 823, Col 21 @ Ln 829, Col 22
+        Ranges: Ln 842, Col 21 @ Ln 848, Col 22
   - !<Text>
     Identifier: 1fa04de
     Algorithm: sha1
@@ -1073,7 +1073,7 @@ Texts:
       - !<Location>
         Identifier: af71ace:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 595, Col 21 @ Ln 598, Col 22
+        Ranges: Ln 612, Col 21 @ Ln 615, Col 22
   - !<Text>
     Identifier: 5fafea5
     Algorithm: sha1
@@ -1085,7 +1085,7 @@ Texts:
       - !<Location>
         Identifier: 5fafea5:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 717, Col 21 @ Ln 717, Col 85
+        Ranges: Ln 735, Col 21 @ Ln 735, Col 85
   - !<Text>
     Identifier: 99db36b
     Algorithm: sha1
@@ -1121,7 +1121,7 @@ Texts:
       - !<Location>
         Identifier: 9d61612:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 723, Col 21 @ Ln 728, Col 22
+        Ranges: Ln 741, Col 21 @ Ln 746, Col 22
   - !<Text>
     Identifier: e510a31
     Algorithm: sha1
@@ -1147,7 +1147,7 @@ Texts:
       - !<Location>
         Identifier: ad77e09:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 541, Col 20 @ Ln 544, Col 14
+        Ranges: Ln 558, Col 20 @ Ln 561, Col 14
   - !<Text>
     Identifier: 9670dfb
     Algorithm: sha1
@@ -1159,7 +1159,7 @@ Texts:
       - !<Location>
         Identifier: 9670dfb:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 476, Col 21 @ Ln 476, Col 76
+        Ranges: Ln 493, Col 21 @ Ln 493, Col 76
   - !<Text>
     Identifier: 0d592d3
     Algorithm: sha1
@@ -1173,7 +1173,7 @@ Texts:
       - !<Location>
         Identifier: 0d592d3:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 806, Col 21 @ Ln 809, Col 22
+        Ranges: Ln 825, Col 21 @ Ln 828, Col 22
   - !<Text>
     Identifier: e2d8fab
     Algorithm: sha1
@@ -1187,7 +1187,7 @@ Texts:
       - !<Location>
         Identifier: e2d8fab:l1
         Path: ./R/ui-sidebar.R
-        Ranges: Ln 309, Col 50 @ Ln 312, Col 14
+        Ranges: Ln 314, Col 50 @ Ln 317, Col 14
   - !<Text>
     Identifier: 378fb16
     Algorithm: sha1
@@ -1199,7 +1199,7 @@ Texts:
       - !<Location>
         Identifier: 378fb16:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 246, Col 13 @ Ln 246, Col 47
+        Ranges: Ln 261, Col 13 @ Ln 261, Col 47
   - !<Text>
     Identifier: a2acebe
     Algorithm: sha1
@@ -1213,7 +1213,7 @@ Texts:
       - !<Location>
         Identifier: a2acebe:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 562, Col 21 @ Ln 565, Col 22
+        Ranges: Ln 579, Col 21 @ Ln 582, Col 22
   - !<Text>
     Identifier: da9cc89
     Algorithm: sha1
@@ -1275,7 +1275,7 @@ Texts:
       - !<Location>
         Identifier: b267cef:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 461, Col 25 @ Ln 468, Col 26
+        Ranges: Ln 478, Col 25 @ Ln 485, Col 26
   - !<Text>
     Identifier: 8cbc334
     Algorithm: sha1
@@ -1287,7 +1287,7 @@ Texts:
       - !<Location>
         Identifier: 8cbc334:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 642, Col 21 @ Ln 642, Col 85
+        Ranges: Ln 660, Col 21 @ Ln 660, Col 85
   - !<Text>
     Identifier: ea57967
     Algorithm: sha1
@@ -1299,7 +1299,7 @@ Texts:
       - !<Location>
         Identifier: ea57967:l1
         Path: ./R/ui-sidebar.R
-        Ranges: Ln 296, Col 27 @ Ln 296, Col 82
+        Ranges: Ln 301, Col 27 @ Ln 301, Col 82
   - !<Text>
     Identifier: b66eca7
     Algorithm: sha1
@@ -1373,7 +1373,7 @@ Texts:
       - !<Location>
         Identifier: 5f12363:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 431, Col 21 @ Ln 431, Col 83
+        Ranges: Ln 448, Col 21 @ Ln 448, Col 83
   - !<Text>
     Identifier: 21d66f8
     Algorithm: sha1
@@ -1443,7 +1443,7 @@ Texts:
       - !<Location>
         Identifier: 5518029:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 500, Col 21 @ Ln 502, Col 14
+        Ranges: Ln 517, Col 21 @ Ln 519, Col 14
   - !<Text>
     Identifier: 501a2ee
     Algorithm: sha1
@@ -1472,7 +1472,7 @@ Texts:
       - !<Location>
         Identifier: 4dd1267:l1
         Path: ./R/ui-sidebar.R
-        Ranges: Ln 321, Col 50 @ Ln 328, Col 14
+        Ranges: Ln 326, Col 50 @ Ln 333, Col 14
   - !<Text>
     Identifier: 3710c88
     Algorithm: sha1
@@ -1487,7 +1487,7 @@ Texts:
       - !<Location>
         Identifier: 3710c88:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 840, Col 29 @ Ln 846, Col 30
+        Ranges: Ln 859, Col 29 @ Ln 865, Col 30
   - !<Text>
     Identifier: a5a2911
     Algorithm: sha1
@@ -1552,7 +1552,7 @@ Texts:
       - !<Location>
         Identifier: 20a872f:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 385, Col 21 @ Ln 389, Col 22
+        Ranges: Ln 401, Col 21 @ Ln 405, Col 22
   - !<Text>
     Identifier: 0e99366
     Algorithm: sha1
@@ -1591,7 +1591,7 @@ Texts:
       - !<Location>
         Identifier: a7c73b7:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 435, Col 21 @ Ln 439, Col 22
+        Ranges: Ln 452, Col 21 @ Ln 456, Col 22
   - !<Text>
     Identifier: 2bbf9dd
     Algorithm: sha1
@@ -1603,7 +1603,7 @@ Texts:
       - !<Location>
         Identifier: 2bbf9dd:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 379, Col 21 @ Ln 381, Col 14
+        Ranges: Ln 395, Col 21 @ Ln 397, Col 14
   - !<Text>
     Identifier: 7d94d60
     Algorithm: sha1
@@ -1632,7 +1632,7 @@ Texts:
       - !<Location>
         Identifier: 1ad7b08:l1
         Path: ./R/ui-sidebar.R
-        Ranges: Ln 281, Col 27 @ Ln 281, Col 67
+        Ranges: Ln 286, Col 27 @ Ln 286, Col 67
   - !<Text>
     Identifier: 81fb05e
     Algorithm: sha1
@@ -1686,7 +1686,7 @@ Texts:
       - !<Location>
         Identifier: ff8d5e3:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 326, Col 20 @ Ln 335, Col 14
+        Ranges: Ln 342, Col 20 @ Ln 351, Col 14
   - !<Text>
     Identifier: 9eef958
     Algorithm: sha1
@@ -1701,7 +1701,7 @@ Texts:
       - !<Location>
         Identifier: 9eef958:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 614, Col 25 @ Ln 619, Col 26
+        Ranges: Ln 631, Col 25 @ Ln 636, Col 26
   - !<Text>
     Identifier: 5dc95f8
     Algorithm: sha1
@@ -1713,7 +1713,7 @@ Texts:
       - !<Location>
         Identifier: 5dc95f8:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 256, Col 13 @ Ln 256, Col 45
+        Ranges: Ln 271, Col 13 @ Ln 271, Col 45
   - !<Text>
     Identifier: c2bb46d
     Algorithm: sha1
@@ -1725,7 +1725,7 @@ Texts:
       - !<Location>
         Identifier: c2bb46d:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 798, Col 21 @ Ln 800, Col 22
+        Ranges: Ln 817, Col 21 @ Ln 819, Col 22
   - !<Text>
     Identifier: 930bac6
     Algorithm: sha1
@@ -1737,7 +1737,7 @@ Texts:
       - !<Location>
         Identifier: 930bac6:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 654, Col 21 @ Ln 654, Col 73
+        Ranges: Ln 672, Col 21 @ Ln 672, Col 73
   - !<Text>
     Identifier: 1b5e945
     Algorithm: sha1
@@ -1749,7 +1749,7 @@ Texts:
       - !<Location>
         Identifier: 1b5e945:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 571, Col 21 @ Ln 574, Col 22
+        Ranges: Ln 588, Col 21 @ Ln 591, Col 22
   - !<Text>
     Identifier: ad9a641
     Algorithm: sha1
@@ -1761,7 +1761,7 @@ Texts:
       - !<Location>
         Identifier: ad9a641:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 341, Col 21 @ Ln 341, Col 65
+        Ranges: Ln 357, Col 21 @ Ln 357, Col 65
   - !<Text>
     Identifier: 02a9a58
     Algorithm: sha1
@@ -1898,7 +1898,7 @@ Texts:
       - !<Location>
         Identifier: bdd75ae:l1
         Path: ./R/ui-sidebar.R
-        Ranges: Ln 353, Col 56 @ Ln 356, Col 14
+        Ranges: Ln 358, Col 56 @ Ln 361, Col 14
   - !<Text>
     Identifier: 4f7aff7
     Algorithm: sha1
@@ -1910,7 +1910,7 @@ Texts:
       - !<Location>
         Identifier: 4f7aff7:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 582, Col 21 @ Ln 582, Col 84
+        Ranges: Ln 599, Col 21 @ Ln 599, Col 84
   - !<Text>
     Identifier: b740be6
     Algorithm: sha1
@@ -1922,7 +1922,7 @@ Texts:
       - !<Location>
         Identifier: b740be6:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 482, Col 21 @ Ln 482, Col 83
+        Ranges: Ln 499, Col 21 @ Ln 499, Col 83
   - !<Text>
     Identifier: 5bbca33
     Algorithm: sha1
@@ -2033,7 +2033,7 @@ Texts:
       - !<Location>
         Identifier: 8141885:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 506, Col 21 @ Ln 511, Col 22
+        Ranges: Ln 523, Col 21 @ Ln 528, Col 22
   - !<Text>
     Identifier: 1a51cee
     Algorithm: sha1
@@ -2059,7 +2059,7 @@ Texts:
       - !<Location>
         Identifier: 899d691:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 666, Col 21 @ Ln 669, Col 22
+        Ranges: Ln 684, Col 21 @ Ln 687, Col 22
   - !<Text>
     Identifier: f0d17dd
     Algorithm: sha1
@@ -2103,7 +2103,7 @@ Texts:
       - !<Location>
         Identifier: fffde19:l1
         Path: ./R/ui-sidebar.R
-        Ranges: Ln 330, Col 61 @ Ln 334, Col 14
+        Ranges: Ln 335, Col 61 @ Ln 339, Col 14
   - !<Text>
     Identifier: 70d45be
     Algorithm: sha1
@@ -2131,7 +2131,7 @@ Texts:
       - !<Location>
         Identifier: 0cdc87d:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 363, Col 21 @ Ln 369, Col 22
+        Ranges: Ln 379, Col 21 @ Ln 385, Col 22
   - !<Text>
     Identifier: 6db5beb
     Algorithm: sha1
@@ -2211,7 +2211,7 @@ Texts:
       - !<Location>
         Identifier: dbb0a02:l1
         Path: ./R/ui-sidebar.R
-        Ranges: Ln 232, Col 13 @ Ln 236, Col 14
+        Ranges: Ln 237, Col 13 @ Ln 241, Col 14
   - !<Text>
     Identifier: b7b4f0b
     Algorithm: sha1
@@ -2242,7 +2242,7 @@ Texts:
       - !<Location>
         Identifier: 9cc07de:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 396, Col 21 @ Ln 403, Col 22
+        Ranges: Ln 412, Col 21 @ Ln 419, Col 22
   - !<Text>
     Identifier: 3116c76
     Algorithm: sha1
@@ -2254,7 +2254,7 @@ Texts:
       - !<Location>
         Identifier: 3116c76:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 751, Col 37 @ Ln 751, Col 68
+        Ranges: Ln 769, Col 37 @ Ln 769, Col 68
   - !<Text>
     Identifier: 449ff93
     Algorithm: sha1
@@ -2286,7 +2286,7 @@ Texts:
       - !<Location>
         Identifier: 9578728:l1
         Path: ./R/ui-footer.R
-        Ranges: Ln 66, Col 17 @ Ln 66, Col 64
+        Ranges: Ln 65, Col 17 @ Ln 65, Col 64
   - !<Text>
     Identifier: 426cfe3
     Algorithm: sha1
@@ -2331,7 +2331,7 @@ Texts:
       - !<Location>
         Identifier: 89fba6b:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 241, Col 13 @ Ln 241, Col 66
+        Ranges: Ln 256, Col 13 @ Ln 256, Col 66
   - !<Text>
     Identifier: ceefbab
     Algorithm: sha1
@@ -2379,7 +2379,7 @@ Texts:
       - !<Location>
         Identifier: 9797b53:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 266, Col 13 @ Ln 272, Col 14
+        Ranges: Ln 281, Col 13 @ Ln 287, Col 14
   - !<Text>
     Identifier: cb21ace
     Algorithm: sha1
@@ -2391,7 +2391,7 @@ Texts:
       - !<Location>
         Identifier: cb21ace:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 584, Col 20 @ Ln 587, Col 14
+        Ranges: Ln 601, Col 20 @ Ln 604, Col 14
   - !<Text>
     Identifier: '7464899'
     Algorithm: sha1
@@ -2403,7 +2403,7 @@ Texts:
       - !<Location>
         Identifier: 7464899:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 236, Col 13 @ Ln 236, Col 43
+        Ranges: Ln 251, Col 13 @ Ln 251, Col 43
   - !<Text>
     Identifier: 8a17368
     Algorithm: sha1
@@ -2415,7 +2415,7 @@ Texts:
       - !<Location>
         Identifier: 8a17368:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 693, Col 25 @ Ln 695, Col 26
+        Ranges: Ln 711, Col 25 @ Ln 713, Col 26
   - !<Text>
     Identifier: a632e97
     Algorithm: sha1
@@ -2509,11 +2509,11 @@ Texts:
       - !<Location>
         Identifier: 380f931:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 697, Col 41 @ Ln 697, Col 72
+        Ranges: Ln 715, Col 41 @ Ln 715, Col 72
       - !<Location>
         Identifier: 380f931:l2
         Path: ./R/ui-sidebar.R
-        Ranges: Ln 222, Col 13 @ Ln 222, Col 46
+        Ranges: Ln 227, Col 13 @ Ln 227, Col 46
   - !<Text>
     Identifier: 4aabcde
     Algorithm: sha1
@@ -2527,7 +2527,7 @@ Texts:
       - !<Location>
         Identifier: 4aabcde:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 676, Col 25 @ Ln 680, Col 26
+        Ranges: Ln 694, Col 25 @ Ln 698, Col 26
   - !<Text>
     Identifier: 9bdd102
     Algorithm: sha1
@@ -2539,7 +2539,7 @@ Texts:
       - !<Location>
         Identifier: 9bdd102:l1
         Path: ./R/ui-sidebar.R
-        Ranges: Ln 306, Col 27 @ Ln 306, Col 65
+        Ranges: Ln 311, Col 27 @ Ln 311, Col 65
   - !<Text>
     Identifier: 4c9bab6
     Algorithm: sha1
@@ -2554,7 +2554,7 @@ Texts:
       - !<Location>
         Identifier: 4c9bab6:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 319, Col 20 @ Ln 324, Col 14
+        Ranges: Ln 335, Col 20 @ Ln 340, Col 14
   - !<Text>
     Identifier: 8c8796c
     Algorithm: sha1
@@ -2566,7 +2566,7 @@ Texts:
       - !<Location>
         Identifier: 8c8796c:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 741, Col 21 @ Ln 741, Col 68
+        Ranges: Ln 759, Col 21 @ Ln 759, Col 68
   - !<Text>
     Identifier: '9616619'
     Algorithm: sha1
@@ -2581,7 +2581,7 @@ Texts:
       - !<Location>
         Identifier: 9616619:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 488, Col 21 @ Ln 492, Col 22
+        Ranges: Ln 505, Col 21 @ Ln 509, Col 22
   - !<Text>
     Identifier: 865ddc6
     Algorithm: sha1
@@ -2623,7 +2623,7 @@ Texts:
       - !<Location>
         Identifier: 1a0644e:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 604, Col 21 @ Ln 607, Col 22
+        Ranges: Ln 621, Col 21 @ Ln 624, Col 22
   - !<Text>
     Identifier: aeaec6e
     Algorithm: sha1
@@ -2637,7 +2637,7 @@ Texts:
       - !<Location>
         Identifier: aeaec6e:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 706, Col 21 @ Ln 709, Col 22
+        Ranges: Ln 724, Col 21 @ Ln 727, Col 22
   - !<Text>
     Identifier: 3eba509
     Algorithm: sha1
@@ -2707,7 +2707,7 @@ Texts:
       - !<Location>
         Identifier: 54697e1:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 656, Col 20 @ Ln 658, Col 14
+        Ranges: Ln 674, Col 20 @ Ln 676, Col 14
   - !<Text>
     Identifier: 4e85c1b
     Algorithm: sha1
@@ -2721,7 +2721,7 @@ Texts:
       - !<Location>
         Identifier: 4e85c1b:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 644, Col 20 @ Ln 648, Col 14
+        Ranges: Ln 662, Col 20 @ Ln 666, Col 14
   - !<Text>
     Identifier: 38210f7
     Algorithm: sha1
@@ -2735,7 +2735,7 @@ Texts:
       - !<Location>
         Identifier: 38210f7:l1
         Path: ./R/ui-modal-faq.R
-        Ranges: Ln 553, Col 21 @ Ln 556, Col 22
+        Ranges: Ln 570, Col 21 @ Ln 573, Col 22
   - !<Text>
     Identifier: 6bf9771
     Algorithm: sha1

--- a/intl/fr.txt
+++ b/intl/fr.txt
@@ -155,14 +155,6 @@ Calculation Parameters
 
 # Insert a translation here.
 
-:: Translations: 00650f3: Source Text
-
-Explore Expostats and other tools.
-
-:: Translations: 00650f3: Translation
-
-# Insert a translation here.
-
 :: Translations: 8f7f102: Source Text
 
 Quantile-Quantile Plot
@@ -554,6 +546,14 @@ Clear
 
 # Insert a translation here.
 
+:: Translations: ecd9787: Source Text
+
+Toogle the current color scheme (light or dark).
+
+:: Translations: ecd9787: Translation
+
+# Insert a translation here.
+
 :: Translations: f3c096c: Source Text
 
 No results are shown in the right panels until inputs are submitted.
@@ -586,14 +586,6 @@ the following scientific paper. Further details and references are also
 available on %s.
 
 :: Translations: f08555d: Translation
-
-# Insert a translation here.
-
-:: Translations: 2e77aed: Source Text
-
-See the source code on GitHub.
-
-:: Translations: 2e77aed: Translation
 
 # Insert a translation here.
 
@@ -765,14 +757,6 @@ split into distinct subsets, or that some outliers must be investigated.
 
 # Insert a translation here.
 
-:: Translations: 59f9427: Source Text
-
-Submit a bug or provide feedback to the maintainers.
-
-:: Translations: 59f9427: Translation
-
-# Insert a translation here.
-
 :: Translations: 23eb033: Source Text
 
 Critical Percentile Category
@@ -809,14 +793,6 @@ uncertainty (using the upper limit of the underlying credible interval).
 How should measurements be formatted?
 
 :: Translations: 5f12363: Translation
-
-# Insert a translation here.
-
-:: Translations: 9895a88: Source Text
-
-Get more information on this application and learn how to use it properly.
-
-:: Translations: 9895a88: Translation
 
 # Insert a translation here.
 
@@ -865,14 +841,6 @@ How can I verify that my measurements were successfully imported?
 Exposure Limit
 
 :: Translations: 501a2ee: Translation
-
-# Insert a translation here.
-
-:: Translations: e6a9040: Source Text
-
-Choose your preferred language.
-
-:: Translations: e6a9040: Translation
 
 # Insert a translation here.
 
@@ -996,6 +964,14 @@ Exposure Limit:
 Value
 
 :: Translations: 81fb05e: Translation
+
+# Insert a translation here.
+
+:: Translations: cb9ddbb: Source Text
+
+Submit a bug or provide feedback to the maintainers by email.
+
+:: Translations: cb9ddbb: Translation
 
 # Insert a translation here.
 
@@ -1278,6 +1254,14 @@ limit (OEL). It must be between 0% and 100%. The traditional default value is
 
 # Insert a translation here.
 
+:: Translations: 70d45be: Source Text
+
+Language
+
+:: Translations: 70d45be: Translation
+
+# Insert a translation here.
+
 :: Translations: 0cdc87d: Source Text
 
 %s and %s currently maintains Tool 1. Ununoctium is an external collaborator
@@ -1329,15 +1313,6 @@ Always put a leading zero before decimals for numbers strictly smaller than
 one. Always use a dot for decimals. Do not use a separator for thousands.
 
 :: Translations: dbb0a02: Translation
-
-# Insert a translation here.
-
-:: Translations: 0705c1d: Source Text
-
-Choose your preferred color scheme. This is an experimental feature. Contents
-may not be displayed appropriately.
-
-:: Translations: 0705c1d: Translation
 
 # Insert a translation here.
 
@@ -1423,6 +1398,14 @@ Density
 
 # Insert a translation here.
 
+:: Translations: 5d328be: Source Text
+
+See the source code of Tool 1 on GitHub.
+
+:: Translations: 5d328be: Translation
+
+# Insert a translation here.
+
 :: Translations: 9797b53: Source Text
 
 Tool 1 assumes that the measurements represent a random sample drawn from the
@@ -1439,6 +1422,14 @@ being assessed.
 Censored measurements are subject to one of the following procedures.
 
 :: Translations: cb21ace: Translation
+
+# Insert a translation here.
+
+:: Translations: 7464899: Source Text
+
+FAQ
+
+:: Translations: 7464899: Translation
 
 # Insert a translation here.
 

--- a/intl/fr.txt
+++ b/intl/fr.txt
@@ -368,6 +368,17 @@ Variant:
 
 # Insert a translation here.
 
+:: Translations: 68c086f: Source Text
+
+The measurement dataset. There must be one value per line. Values can be
+censored to the left (<), to the right (>), or interval censored ([X-Y]). For
+more information, see the Calculation Parameters section in Frequently Asked
+Questions (FAQ) above.
+
+:: Translations: 68c086f: Translation
+
+# Insert a translation here.
+
 :: Translations: d257a4e: Source Text
 
 ≤ 1% OEL
@@ -1598,15 +1609,6 @@ Use this value to change the color of exposures that are below the exposure
 limit.
 
 :: Translations: 2502705: Translation
-
-# Insert a translation here.
-
-:: Translations: 2b83cc5: Source Text
-
-The measurement dataset. There must be one value per line. Values can be
-censored to the left (<), to the right (>), or interval censored ([X-Y]).
-
-:: Translations: 2b83cc5: Translation
 
 # Insert a translation here.
 

--- a/rsconnect/shinyapps.io/lavoue/tool1-beta.dcf
+++ b/rsconnect/shinyapps.io/lavoue/tool1-beta.dcf
@@ -1,0 +1,17 @@
+name: tool1-beta
+title: Tool1: Data Interpretation for One Similar Exposure Group (SEG)
+username: lavoue
+account: lavoue
+server: shinyapps.io
+hostUrl: https://api.shinyapps.io/v1
+appId: 14521166
+bundleId:
+url: https://lavoue.shinyapps.io/tool1-beta/
+version: 1
+region: dev
+version_number: 4.1.0
+version_release_date: 2025-04-15
+license: MIT + file LICENSE
+bug_reports: https://github.com/webexpo/app-tool1/issues
+encoding: UTF-8
+language: en

--- a/rsconnect/shinyapps.io/lavoue/tool1-beta.dcf
+++ b/rsconnect/shinyapps.io/lavoue/tool1-beta.dcf
@@ -5,12 +5,12 @@ account: lavoue
 server: shinyapps.io
 hostUrl: https://api.shinyapps.io/v1
 appId: 14521166
-bundleId: 10119967
+bundleId: 10125909
 url: https://lavoue.shinyapps.io/tool1-beta/
 version: 1
 region: dev
 version_number: 4.1.0
-version_release_date: 2025-04-15
+version_release_date: 2025-04-16
 license: MIT + file LICENSE
 bug_reports: https://github.com/webexpo/app-tool1/issues
 encoding: UTF-8

--- a/rsconnect/shinyapps.io/lavoue/tool1-beta.dcf
+++ b/rsconnect/shinyapps.io/lavoue/tool1-beta.dcf
@@ -5,7 +5,7 @@ account: lavoue
 server: shinyapps.io
 hostUrl: https://api.shinyapps.io/v1
 appId: 14521166
-bundleId:
+bundleId: 10119736
 url: https://lavoue.shinyapps.io/tool1-beta/
 version: 1
 region: dev

--- a/rsconnect/shinyapps.io/lavoue/tool1-beta.dcf
+++ b/rsconnect/shinyapps.io/lavoue/tool1-beta.dcf
@@ -5,7 +5,7 @@ account: lavoue
 server: shinyapps.io
 hostUrl: https://api.shinyapps.io/v1
 appId: 14521166
-bundleId: 10119736
+bundleId: 10119967
 url: https://lavoue.shinyapps.io/tool1-beta/
 version: 1
 region: dev

--- a/rsconnect/shinyapps.io/lavoue/tool1.dcf
+++ b/rsconnect/shinyapps.io/lavoue/tool1.dcf
@@ -5,11 +5,12 @@ account: lavoue
 server: shinyapps.io
 hostUrl: https://api.shinyapps.io/v1
 appId: 13889847
-bundleId: 10100561
+bundleId: 10125934
 url: https://lavoue.shinyapps.io/tool1/
 version: 1
-version_number: 4.0.0
-version_release_date: 2025-04-11
+region: prod
+version_number: 4.1.0
+version_release_date: 2025-04-16
 license: MIT + file LICENSE
 bug_reports: https://github.com/webexpo/app-tool1/issues
 encoding: UTF-8

--- a/www/main.css
+++ b/www/main.css
@@ -9,7 +9,9 @@ p {
 }
 
 /* Change buttons to make them a
-   little bit bigger or smaller. */
+   little bit bigger or smaller.
+   Colors rules allow appropriate
+   usage of dark mode. */
 .app-btn {
   --bs-btn-padding-y: 0.25rem;
   --bs-btn-padding-x: 0.75rem;
@@ -17,11 +19,10 @@ p {
   color: var(--bs-body-color);
 }
 
-.app-btn-small {
-  --bs-btn-padding-y: 0.25rem;
-  --bs-btn-padding-x: 0.5rem;
-  --bs-btn-font-size: 1rem;
-  color: var(--bs-body-color);
+/* App buttons used inside nav
+   items are colored as such. */
+.nav-item .app-btn {
+  color: var(--bs-nav-link-color);
 }
 
 .app-rotated-minus-90 {
@@ -67,12 +68,4 @@ p {
   /* Change the space between each active
      <nav> element and its underline. */
   padding: 8px 5px !important;
-}
-
-/* Display elements only on bigger
-   screens of at least 1500px. */
-@media screen and (max-width: 1499px) {
-  .app-large-screen-only {
-    display: none;
-  }
 }

--- a/www/main.css
+++ b/www/main.css
@@ -13,7 +13,7 @@ p {
 .app-btn {
   --bs-btn-padding-y: 0.25rem;
   --bs-btn-padding-x: 0.75rem;
-  --bs-btn-font-size: 1.5rem;
+  --bs-btn-font-size: 1.25rem;
   color: var(--bs-body-color);
 }
 

--- a/www/main.css
+++ b/www/main.css
@@ -25,6 +25,10 @@ p {
   color: var(--bs-nav-link-color);
 }
 
+.nav-item .app-btn:hover {
+  color: #fff;
+}
+
 .app-rotated-minus-90 {
   transform: rotate(-90deg);
 }

--- a/www/main.css
+++ b/www/main.css
@@ -71,5 +71,5 @@ p {
 .app-navset-bar-fix a.nav-link.active {
   /* Change the space between each active
      <nav> element and its underline. */
-  padding: 8px 5px !important;
+  padding: 8px 5px 16px 5px !important;
 }


### PR DESCRIPTION
## Release

This PR is tied to the `4.1.0` **minor** release (`2025-04-16`).

## Changes

This PR introduces minor changes to support a wide variety of screens, including small cellphones. A device screen having a width of at least `375` pixels is recommended, but the application should be able to support even smaller screens.

Most elements were already responsive. Most of the work focused on the Title Bar module (which is fully custom).

This PR further introduces small optimizations for faster page loading when `lang` is `"en"`.

Other changes are listed in a new [`NEWS.md`](https://github.com/webexpo/tool1/blob/main/NEWS.md) file.